### PR TITLE
feat: ArduPilot param docs links and MP/QGC param file I/O

### DIFF
--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -114,7 +114,21 @@ import { IPC_CHANNELS, SEVERITY_LABELS, type ConnectOptions, type ConnectionStat
 import { DEFAULT_USER_UNIT_PREFERENCES } from '../shared/user-units.js';
 import { initAutoUpdater, checkForUpdates, downloadUpdate, installUpdate } from './updater.js';
 import type { ParamValuePayload, ParameterProgress } from '../shared/parameter-types.js';
-import { PARAMETER_METADATA_URLS, mavTypeToVehicleType, type VehicleType, type ParameterMetadata, type ParameterMetadataStore } from '../shared/parameter-metadata.js';
+import {
+  PARAMETER_METADATA_URLS,
+  mavTypeToVehicleType,
+  firmwareVersionTagFromFlightSwVersion,
+  type VehicleType,
+  type ParameterMetadata,
+  type ParameterMetadataStore,
+} from '../shared/parameter-metadata.js';
+import {
+  parseParamFile,
+  serializeParamFile,
+  extractVehicleTypeFromParamFile,
+  detectParamFileFormat,
+  type ParamFileFormat,
+} from '../shared/param-file-parser.js';
 import type { AttitudeData, PositionData, GpsData, BatteryData, VfrHudData, FlightState, RcChannelsData, NavControllerData } from '../shared/telemetry-types.js';
 import { COPTER_MODES, PLANE_MODES, ROVER_MODES, SUB_MODES } from '../shared/telemetry-types.js';
 import type { MissionItem, MissionProgress, MavFrame } from '../shared/mission-types.js';
@@ -2886,6 +2900,12 @@ function parseTelemetry(mainWindow: BrowserWindow, packet: MAVLinkPacket): void 
             const patch = (flightSwVersion >> 8) & 0xFF;
             const vType = flightSwVersion & 0xFF;
             const typeLabel = vType === 255 ? 'official' : vType >= 192 ? `rc${vType - 191}` : vType >= 128 ? `beta${vType - 127}` : vType >= 64 ? `alpha` : 'dev';
+            // Only expose stable official releases for versioned Sphinx docs URLs.
+            const versionTag = firmwareVersionTagFromFlightSwVersion(flightSwVersion);
+            if (connectionState.firmwareVersion !== versionTag) {
+              connectionState.firmwareVersion = versionTag;
+              sendConnectionState(mainWindow);
+            }
             sendLog(mainWindow, 'info', `Firmware: ${connectionState.vehicleType ?? 'ArduPilot'} v${major}.${minor}.${patch} (${typeLabel})`);
           }
 
@@ -7577,48 +7597,74 @@ export function setupIpcHandlers(mainWindow: BrowserWindow): void {
     }
   });
 
-  // Save parameters to file
-  ipcMain.handle(IPC_CHANNELS.PARAM_SAVE_FILE, async (_, params: Array<{ id: string; value: number }>, vehicleType?: string): Promise<{ success: boolean; error?: string; filePath?: string }> => {
+  // Save parameters to file (Mission Planner .param or QGC .params)
+  ipcMain.handle(IPC_CHANNELS.PARAM_SAVE_FILE, async (
+    _,
+    params: Array<{ id: string; value: number; type?: number }>,
+    vehicleType?: string,
+    options?: { format?: 'mp' | 'qgc' },
+  ): Promise<{ success: boolean; error?: string; filePath?: string; format?: 'mp' | 'qgc' }> => {
     try {
+      const preferredFormat = options?.format ?? 'mp';
       const result = await dialog.showSaveDialog(mainWindow, {
-        title: 'Save Parameters',
-        defaultPath: 'parameters.param',
-        filters: [
-          { name: 'Parameter Files', extensions: ['param'] },
-          { name: 'Text Files', extensions: ['txt'] },
-          { name: 'All Files', extensions: ['*'] },
-        ],
+        title: preferredFormat === 'qgc' ? 'Save Parameters (QGroundControl)' : 'Save Parameters',
+        defaultPath: preferredFormat === 'qgc' ? 'parameters.params' : 'parameters.param',
+        filters: preferredFormat === 'qgc'
+          ? [
+              { name: 'QGroundControl Parameter Files', extensions: ['params'] },
+              { name: 'Mission Planner Parameter Files', extensions: ['param'] },
+              { name: 'Text Files', extensions: ['txt'] },
+              { name: 'All Files', extensions: ['*'] },
+            ]
+          : [
+              { name: 'Mission Planner Parameter Files', extensions: ['param'] },
+              { name: 'QGroundControl Parameter Files', extensions: ['params'] },
+              { name: 'Text Files', extensions: ['txt'] },
+              { name: 'All Files', extensions: ['*'] },
+            ],
       });
 
       if (result.canceled || !result.filePath) {
         return { success: false, error: 'Cancelled' };
       }
 
-      // Header with vehicle type and timestamp for cross-vehicle-type safety
-      const header = [
-        `# ArduDeck Parameter File`,
-        vehicleType ? `# Vehicle: ${vehicleType}` : null,
-        `# Date: ${new Date().toISOString()}`,
-        `# Parameters: ${params.length}`,
-        '',
-      ].filter(Boolean).join('\n');
+      // Choose format from extension when user overrides the filter
+      const lowerPath = result.filePath.toLowerCase();
+      let format: 'mp' | 'qgc' = preferredFormat;
+      if (lowerPath.endsWith('.params')) format = 'qgc';
+      else if (lowerPath.endsWith('.param')) format = 'mp';
 
-      // Format: PARAM_NAME,VALUE (one per line)
-      // MAVLink parameters are 32-bit floats. When decoded into JS 64-bit doubles
-      // they carry floating-point noise (e.g. 0.18000000715255737 instead of 0.18).
-      // toPrecision(6) recovers the original 6 significant digits; parseFloat strips
-      // trailing zeros so integers stored as floats still look clean (e.g. "1" not "1.00000").
-      const formatValue = (value: number): string => {
-        if (Number.isInteger(value)) return String(value);
-        return String(parseFloat(value.toPrecision(6)));
-      };
-      const content = header + '\n\n' + params.map(p => `${p.id},${formatValue(p.value)}`).join('\n');
+      const headerComments =
+        format === 'mp'
+          ? [
+              'ArduDeck Parameter File',
+              ...(vehicleType ? [`Vehicle: ${vehicleType}`] : []),
+              `Date: ${new Date().toISOString()}`,
+              `Parameters: ${params.length}`,
+            ]
+          : [
+              'Onboard parameters',
+              'VEHICLE_ID COMPONENT_ID NAME VALUE TYPE',
+              ...(vehicleType ? [`Vehicle: ${vehicleType}`] : []),
+              `Date: ${new Date().toISOString()}`,
+              `Parameters: ${params.length}`,
+            ];
+
+      const content = serializeParamFile(
+        params.map((p) => ({ name: p.id, value: p.value, type: p.type })),
+        {
+          format,
+          systemId: connectionState.systemId ?? 1,
+          componentId: connectionState.componentId ?? 1,
+          headerComments,
+        },
+      );
 
       const fs = await import('fs/promises');
       await fs.writeFile(result.filePath, content, 'utf-8');
 
-      sendLog(mainWindow, 'info', `Saved ${params.length} parameters to ${result.filePath}`);
-      return { success: true, filePath: result.filePath };
+      sendLog(mainWindow, 'info', `Saved ${params.length} parameters to ${result.filePath} (${format})`);
+      return { success: true, filePath: result.filePath, format };
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       sendLog(mainWindow, 'error', 'Failed to save parameters', message);
@@ -7696,12 +7742,21 @@ export function setupIpcHandlers(mainWindow: BrowserWindow): void {
     }
   });
 
-  ipcMain.handle(IPC_CHANNELS.PARAM_LOAD_FILE, async (): Promise<{ success: boolean; error?: string; params?: Array<{ id: string; value: number }>; vehicleType?: string; filePath?: string }> => {
+  ipcMain.handle(IPC_CHANNELS.PARAM_LOAD_FILE, async (): Promise<{
+    success: boolean;
+    error?: string;
+    params?: Array<{ id: string; value: number; type?: number }>;
+    vehicleType?: string;
+    filePath?: string;
+    format?: ParamFileFormat;
+  }> => {
     try {
       const result = await dialog.showOpenDialog(mainWindow, {
         title: 'Load Parameters',
         filters: [
-          { name: 'Parameter Files', extensions: ['param'] },
+          { name: 'Parameter Files', extensions: ['param', 'params'] },
+          { name: 'Mission Planner', extensions: ['param'] },
+          { name: 'QGroundControl', extensions: ['params'] },
           { name: 'Text Files', extensions: ['txt'] },
           { name: 'All Files', extensions: ['*'] },
         ],
@@ -7716,43 +7771,26 @@ export function setupIpcHandlers(mainWindow: BrowserWindow): void {
       const fs = await import('fs/promises');
       const content = await fs.readFile(filePath, 'utf-8');
 
-      // Parse: PARAM_NAME,VALUE (one per line)
-      // Also supports PARAM_NAME VALUE (space-separated, like Mission Planner)
-      const params: Array<{ id: string; value: number }> = [];
-      let vehicleType: string | undefined;
-      const lines = content.split(/\r?\n/);
+      const format = detectParamFileFormat(content);
+      const parsed = parseParamFile(content);
+      const vehicleType = extractVehicleTypeFromParamFile(content);
 
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed) continue;
-
-        // Parse header comments for metadata
-        if (trimmed.startsWith('#')) {
-          const vehicleMatch = trimmed.match(/^#\s*Vehicle:\s*(.+)/i);
-          if (vehicleMatch?.[1]) {
-            vehicleType = vehicleMatch[1].trim();
-          }
-          continue;
-        }
-
-        // Try comma-separated first, then space/tab
-        let parts = trimmed.split(',');
-        if (parts.length < 2) {
-          parts = trimmed.split(/\s+/);
-        }
-
-        if (parts.length >= 2) {
-          const id = parts[0]!.trim();
-          const value = parseFloat(parts[1]!.trim());
-
-          if (id && !isNaN(value)) {
-            params.push({ id, value });
-          }
-        }
+      if (parsed.length === 0) {
+        const hint =
+          format === 'unknown'
+            ? 'Unrecognized or empty parameter file (expected Mission Planner .param or QGC .params)'
+            : 'No parameters found in file';
+        sendLog(mainWindow, 'warn', hint, filePath);
+        return { success: false, error: hint, filePath, format };
       }
 
-      sendLog(mainWindow, 'info', `Loaded ${params.length} parameters from ${filePath}${vehicleType ? ` (${vehicleType})` : ''}`);
-      return { success: true, params, vehicleType, filePath };
+      const params = parsed.map((p) => ({ id: p.name, value: p.value, type: p.type }));
+      sendLog(
+        mainWindow,
+        'info',
+        `Loaded ${params.length} parameters from ${filePath}${vehicleType ? ` (${vehicleType})` : ''} [${format}]`,
+      );
+      return { success: true, params, vehicleType, filePath, format };
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       sendLog(mainWindow, 'error', 'Failed to load parameters', message);
@@ -7761,21 +7799,40 @@ export function setupIpcHandlers(mainWindow: BrowserWindow): void {
   });
 
   // Save parameters to a specific file path (offline mode - Save)
-  ipcMain.handle(IPC_CHANNELS.PARAM_SAVE_TO_PATH, async (_, params: Array<{ id: string; value: number }>, filePath: string, vehicleType?: string): Promise<{ success: boolean; error?: string }> => {
+  ipcMain.handle(IPC_CHANNELS.PARAM_SAVE_TO_PATH, async (
+    _,
+    params: Array<{ id: string; value: number; type?: number }>,
+    filePath: string,
+    vehicleType?: string,
+  ): Promise<{ success: boolean; error?: string }> => {
     try {
-      const header = [
-        `# ArduDeck Parameter File`,
-        vehicleType ? `# Vehicle: ${vehicleType}` : null,
-        `# Date: ${new Date().toISOString()}`,
-        `# Parameters: ${params.length}`,
-        '',
-      ].filter(Boolean).join('\n');
+      const lowerPath = filePath.toLowerCase();
+      const format: 'mp' | 'qgc' = lowerPath.endsWith('.params') ? 'qgc' : 'mp';
+      const headerComments =
+        format === 'mp'
+          ? [
+              'ArduDeck Parameter File',
+              ...(vehicleType ? [`Vehicle: ${vehicleType}`] : []),
+              `Date: ${new Date().toISOString()}`,
+              `Parameters: ${params.length}`,
+            ]
+          : [
+              'Onboard parameters',
+              'VEHICLE_ID COMPONENT_ID NAME VALUE TYPE',
+              ...(vehicleType ? [`Vehicle: ${vehicleType}`] : []),
+              `Date: ${new Date().toISOString()}`,
+              `Parameters: ${params.length}`,
+            ];
 
-      const formatValue = (value: number): string => {
-        if (Number.isInteger(value)) return String(value);
-        return String(parseFloat(value.toPrecision(6)));
-      };
-      const content = header + '\n\n' + params.map(p => `${p.id},${formatValue(p.value)}`).join('\n');
+      const content = serializeParamFile(
+        params.map((p) => ({ name: p.id, value: p.value, type: p.type })),
+        {
+          format,
+          systemId: connectionState.systemId ?? 1,
+          componentId: connectionState.componentId ?? 1,
+          headerComments,
+        },
+      );
 
       const fs = await import('fs/promises');
       await fs.writeFile(filePath, content, 'utf-8');

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -598,13 +598,28 @@ const api = {
   writeParamsToFlash: (): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke(IPC_CHANNELS.PARAM_WRITE_FLASH),
 
-  saveParamsToFile: (params: Array<{ id: string; value: number }>, vehicleType?: string): Promise<{ success: boolean; error?: string; filePath?: string }> =>
-    ipcRenderer.invoke(IPC_CHANNELS.PARAM_SAVE_FILE, params, vehicleType),
+  saveParamsToFile: (
+    params: Array<{ id: string; value: number; type?: number }>,
+    vehicleType?: string,
+    options?: { format?: 'mp' | 'qgc' },
+  ): Promise<{ success: boolean; error?: string; filePath?: string; format?: 'mp' | 'qgc' }> =>
+    ipcRenderer.invoke(IPC_CHANNELS.PARAM_SAVE_FILE, params, vehicleType, options),
 
-  loadParamsFromFile: (): Promise<{ success: boolean; error?: string; params?: Array<{ id: string; value: number }>; vehicleType?: string; filePath?: string }> =>
+  loadParamsFromFile: (): Promise<{
+    success: boolean;
+    error?: string;
+    params?: Array<{ id: string; value: number; type?: number }>;
+    vehicleType?: string;
+    filePath?: string;
+    format?: 'mp' | 'qgc' | 'unknown';
+  }> =>
     ipcRenderer.invoke(IPC_CHANNELS.PARAM_LOAD_FILE),
 
-  saveParamsToPath: (params: Array<{ id: string; value: number }>, filePath: string, vehicleType?: string): Promise<{ success: boolean; error?: string }> =>
+  saveParamsToPath: (
+    params: Array<{ id: string; value: number; type?: number }>,
+    filePath: string,
+    vehicleType?: string,
+  ): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke(IPC_CHANNELS.PARAM_SAVE_TO_PATH, params, filePath, vehicleType),
 
   // Parameter history (version control)

--- a/apps/desktop/src/renderer/components/mavlink-config/ParameterTable.tsx
+++ b/apps/desktop/src/renderer/components/mavlink-config/ParameterTable.tsx
@@ -12,12 +12,14 @@ import { useParameterStore, type SortColumn } from '../../stores/parameter-store
 import { useSettingsStore } from '../../stores/settings-store';
 import { PARAMETER_GROUPS } from '../../../shared/parameter-groups';
 import { useConnectionStore } from '../../stores/connection-store';
-import { getParameterDocsUrl, mavTypeToVehicleType } from '../../../shared/parameter-metadata';
+import { getParameterDocsUrl, resolveArduPilotDocsContext } from '../../../shared/parameter-metadata';
 import { formatParamValue } from '../../../shared/parameter-types';
+import { formatParamDisplayValue, isIntegerishParamValue, paramValueAsEnumKey } from '../../../shared/param-display';
 import { classifySitlUnsafeParam } from '../../../shared/sitl-unsafe-params';
 import BitmaskEditor from './BitmaskEditor';
 import ParamHistoryModal from './ParamHistoryModal';
 import { Tooltip } from '../ui/Tooltip';
+import { ParamNameTooltip } from '../ui/ParamNameTooltip';
 import { NON_DEFAULT_COLORS, getNonDefaultColor } from '../parameters/non-default-palette';
 
 // Toast notification state
@@ -413,20 +415,22 @@ const ParameterTable: React.FC = () => {
     closeCompareModal();
   }, [fileApplyResult, clearFileApplyResult, closeCompareModal]);
 
-  const handleSaveToFile = useCallback(async (changedOnly?: boolean) => {
+  const handleSaveToFile = useCallback(async (opts?: { changedOnly?: boolean; format?: 'mp' | 'qgc' }) => {
+    const changedOnly = opts?.changedOnly ?? false;
+    const format = opts?.format ?? 'mp';
     setIsSavingFile(true);
     setSaveDropdownOpen(false);
     try {
       let params = Array.from(parameters.values())
         .filter(p => !p.isReadOnly)
         .sort((a, b) => a.id.localeCompare(b.id))
-        .map(p => ({ id: p.id, value: p.value }));
+        .map(p => ({ id: p.id, value: p.value, type: p.type }));
 
       if (changedOnly) {
         params = Array.from(parameters.values())
           .filter(p => !p.isReadOnly && p.isModified)
           .sort((a, b) => a.id.localeCompare(b.id))
-          .map(p => ({ id: p.id, value: p.value }));
+          .map(p => ({ id: p.id, value: p.value, type: p.type }));
       }
 
       if (params.length === 0) {
@@ -435,9 +439,11 @@ const ParameterTable: React.FC = () => {
       }
 
       const vehicleType = connectionState.vehicleType || connectionState.fcVariant;
-      const result = await window.electronAPI?.saveParamsToFile(params, vehicleType);
+      const result = await window.electronAPI?.saveParamsToFile(params, vehicleType, { format });
       if (result?.success) {
-        showToast(`Saved ${params.length} parameter${params.length !== 1 ? 's' : ''} to file`, 'success');
+        const actual = result.format ?? format;
+        const fmtLabel = actual === 'qgc' ? 'QGC' : 'MP';
+        showToast(`Saved ${params.length} parameter${params.length !== 1 ? 's' : ''} (${fmtLabel})`, 'success');
       } else if (result?.error && result.error !== 'Cancelled') {
         showToast(result.error, 'error');
       }
@@ -451,7 +457,19 @@ const ParameterTable: React.FC = () => {
     try {
       const result = await window.electronAPI?.loadParamsFromFile();
       if (result?.success && result.params) {
-        loadFileForCompare(result.params, result.vehicleType);
+        if (result.params.length === 0) {
+          showToast('No parameters found in file', 'error');
+          return;
+        }
+        const { diffs, skipped } = loadFileForCompare(result.params, result.vehicleType);
+        if (diffs === 0 && skipped === 0) {
+          showToast('All parameters in file match current values (no differences)', 'info');
+        } else if (diffs === 0 && skipped > 0) {
+          showToast(
+            `No matching parameters to apply (${skipped} name${skipped !== 1 ? 's' : ''} not on vehicle)`,
+            'info',
+          );
+        }
       } else if (result?.error && result.error !== 'Cancelled') {
         showToast(result.error, 'error');
       }
@@ -540,8 +558,30 @@ const ParameterTable: React.FC = () => {
   const nonDefaultCount = nonDefaultCountFn();
   const hasDefaults = hasDefaultsFn();
 
-  // Vehicle slug for the per-param ArduPilot docs link. Null when vehicle is unknown.
-  const docsVehicle = connectionState.mavType != null ? mavTypeToVehicleType(connectionState.mavType) : null;
+  const offlineVehicleType = useParameterStore((s) => s.offlineVehicleType);
+  const offlineMode = useParameterStore((s) => s.offlineMode);
+
+  // ArduPilot-only docs context (vehicle + optional firmware version for Sphinx pages).
+  const docsContext = useMemo(
+    () =>
+      resolveArduPilotDocsContext({
+        protocol: offlineMode ? undefined : connectionState.protocol,
+        autopilot: offlineMode ? undefined : connectionState.autopilot,
+        mavType: offlineMode ? undefined : connectionState.mavType,
+        vehicleType: connectionState.vehicleType,
+        firmwareVersion: offlineMode ? undefined : connectionState.firmwareVersion,
+        offlineVehicleType: offlineVehicleType ?? undefined,
+      }),
+    [
+      offlineMode,
+      offlineVehicleType,
+      connectionState.protocol,
+      connectionState.autopilot,
+      connectionState.mavType,
+      connectionState.vehicleType,
+      connectionState.firmwareVersion,
+    ],
+  );
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const rowVirtualizer = useVirtualizer({
@@ -573,10 +613,10 @@ const ParameterTable: React.FC = () => {
           <div className="relative" ref={saveDropdownRef}>
             <div className="flex">
               <button
-                onClick={() => handleSaveToFile(false)}
+                onClick={() => handleSaveToFile({ format: 'mp' })}
                 disabled={isSavingFile || paramCount === 0}
                 className="px-3 py-2 bg-surface-raised hover:bg-surface-raised disabled:bg-surface text-content disabled:text-content-tertiary rounded-l-lg text-sm font-medium transition-colors flex items-center gap-2"
-                title="Save all parameters to file"
+                title="Save all parameters to Mission Planner .param file"
               >
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -595,19 +635,33 @@ const ParameterTable: React.FC = () => {
               </button>
             </div>
             {saveDropdownOpen && (
-              <div className="absolute top-full left-0 mt-1 w-52 bg-surface-solid border-subtle rounded-lg shadow-xl z-50 py-1">
+              <div className="absolute top-full left-0 mt-1 w-64 bg-surface-solid border border-subtle rounded-lg shadow-xl z-50 py-1">
                 <button
-                  onClick={() => handleSaveToFile(false)}
+                  onClick={() => handleSaveToFile({ format: 'mp' })}
                   className="w-full px-3 py-2 text-left text-sm text-content hover:bg-surface-raised transition-colors"
                 >
-                  Save All Parameters
+                  Save All (Mission Planner .param)
                 </button>
                 <button
-                  onClick={() => handleSaveToFile(true)}
+                  onClick={() => handleSaveToFile({ format: 'qgc' })}
+                  className="w-full px-3 py-2 text-left text-sm text-content hover:bg-surface-raised transition-colors"
+                >
+                  Save All (QGroundControl .params)
+                </button>
+                <button
+                  onClick={() => handleSaveToFile({ changedOnly: true, format: 'mp' })}
                   disabled={modified === 0}
                   className="w-full px-3 py-2 text-left text-sm text-content hover:bg-surface-raised disabled:text-content-tertiary disabled:hover:bg-transparent transition-colors"
                 >
-                  Save Changed Only
+                  Save Changed Only (.param)
+                  {modified > 0 && <span className="ml-1 text-xs text-yellow-400">({modified})</span>}
+                </button>
+                <button
+                  onClick={() => handleSaveToFile({ changedOnly: true, format: 'qgc' })}
+                  disabled={modified === 0}
+                  className="w-full px-3 py-2 text-left text-sm text-content hover:bg-surface-raised disabled:text-content-tertiary disabled:hover:bg-transparent transition-colors"
+                >
+                  Save Changed Only (.params)
                   {modified > 0 && <span className="ml-1 text-xs text-yellow-400">({modified})</span>}
                 </button>
               </div>
@@ -943,7 +997,17 @@ const ParameterTable: React.FC = () => {
                       >
                         <Star className={`w-3.5 h-3.5 ${isFavourite(param.id) ? 'fill-yellow-400 text-yellow-400' : 'text-content-tertiary hover:text-content-secondary'}`} />
                       </button>
-                      <span className="font-mono text-sm text-content truncate">{param.id}</span>
+                      <ParamNameTooltip
+                        meta={getParameterMetadata(param.id)}
+                        description={getDescription(param.id)}
+                        docUrl={
+                          docsContext
+                            ? getParameterDocsUrl(docsContext.vehicleType, param.id, docsContext.versionTag)
+                            : null
+                        }
+                      >
+                        <span className="font-mono text-sm text-content truncate cursor-help">{param.id}</span>
+                      </ParamNameTooltip>
                       {isRebootRequired(param.id) && (
                         <span className="shrink-0 px-1 py-0.5 text-[9px] leading-none bg-amber-500/15 text-amber-500/70 rounded border-amber-500/20" title="Requires reboot to take effect">
                           Reboot
@@ -954,7 +1018,7 @@ const ParameterTable: React.FC = () => {
                   <div className="px-4 py-2.5 min-w-0">
                     {param.isReadOnly ? (
                       <span className="font-mono text-sm text-content-secondary tabular-nums" title="Read-only parameter">
-                        {formatParamValue(param.value)}
+                        {formatParamDisplayValue(param.value, getParameterMetadata(param.id))}
                       </span>
                     ) : editingParam === param.id ? (
                       <div className="relative">
@@ -980,23 +1044,24 @@ const ParameterTable: React.FC = () => {
                     ) : (() => {
                       const meta = getParameterMetadata(param.id);
                       const hasBitmask = meta?.bitmask && Object.keys(meta.bitmask).length > 0;
-                      // Only show enum dropdown for integer-valued params (not float suggestions like expo)
-                      const isIntegerParam = Number.isInteger(param.value);
+                      // Only show enum dropdown for integer-like params (float32-aware; not float expo suggestions)
+                      const isIntegerParam = isIntegerishParamValue(param.value);
+                      const enumKey = paramValueAsEnumKey(param.value);
                       const hasEnumValues = !hasBitmask && isIntegerParam && meta?.values && Object.keys(meta.values).length > 0;
                       return (
                         <div className="relative flex items-center gap-1.5 min-w-0">
                           {hasEnumValues ? (
                             <div className="flex items-center gap-1 w-full">
                               <select
-                                value={Math.round(param.value)}
+                                value={enumKey}
                                 onChange={(e) => setParameter(param.id, Number(e.target.value))}
                                 className={`flex-1 min-w-0 h-7 px-2 bg-surface-input border rounded-md text-sm leading-none focus:outline-none focus:border-blue-500 truncate ${isNonDefault ? nonDefaultColor.textClass : 'text-content'}`}
                               >
                                 {Object.entries(meta!.values!).map(([code, label]) => (
-                                  <option key={code} value={code}>{code}: {label}</option>
+                                  <option key={code} value={code}>{code} — {label}</option>
                                 ))}
-                                {!(String(Math.round(param.value)) in meta!.values!) && (
-                                  <option value={Math.round(param.value)}>{Math.round(param.value)}: Custom</option>
+                                {!(String(enumKey) in meta!.values!) && (
+                                  <option value={enumKey}>{enumKey} — Custom</option>
                                 )}
                               </select>
                               <button
@@ -1011,7 +1076,7 @@ const ParameterTable: React.FC = () => {
                             <>
                               <button
                                 onClick={() => startEdit(param.id, param.value)}
-                                className={`font-mono text-sm hover:text-blue-400 transition-colors tabular-nums ${isNonDefault ? nonDefaultColor.textClass : 'text-content'}`}
+                                className={`font-mono text-sm hover:text-blue-400 transition-colors tabular-nums truncate ${isNonDefault ? nonDefaultColor.textClass : 'text-content'}`}
                                 title={(() => {
                                   const hints: string[] = [];
                                   if (isNonDefault && param.defaultValue !== undefined) {
@@ -1021,7 +1086,7 @@ const ParameterTable: React.FC = () => {
                                   return hints.join('\n') || `Click to edit`;
                                 })()}
                               >
-                                {formatParamValue(param.value)}
+                                {formatParamDisplayValue(param.value, meta)}
                               </button>
                               {meta?.units && (
                                 <span className="text-[11px] text-content-tertiary ml-1 truncate">{meta.units}</span>
@@ -1056,8 +1121,8 @@ const ParameterTable: React.FC = () => {
                       const meta = getParameterMetadata(param.id);
                       const hasVals = !meta?.bitmask && meta?.values && Object.keys(meta.values).length > 0;
                       if (!hasVals) return null;
-                      const isInt = Number.isInteger(param.value);
-                      const currentCode = String(isInt ? Math.round(param.value) : param.value);
+                      const isInt = isIntegerishParamValue(param.value);
+                      const currentCode = String(isInt ? paramValueAsEnumKey(param.value) : param.value);
                       return (
                         <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] leading-snug max-h-[34px] overflow-hidden">
                           {Object.entries(meta!.values!).map(([code, label]) => {
@@ -1099,12 +1164,18 @@ const ParameterTable: React.FC = () => {
                         {getDescription(param.id)}
                       </span>
                     </Tooltip>
-                    {docsVehicle && (
+                    {docsContext && (
                       <Tooltip content="Open ArduPilot docs" placement="top">
                         <button
                           onClick={(e) => {
                             e.stopPropagation();
-                            window.electronAPI?.openExternal(getParameterDocsUrl(docsVehicle, param.id));
+                            window.electronAPI?.openExternal(
+                              getParameterDocsUrl(
+                                docsContext.vehicleType,
+                                param.id,
+                                docsContext.versionTag,
+                              ),
+                            );
                           }}
                           className="shrink-0 p-1 rounded text-content-tertiary hover:text-blue-400 hover:bg-surface-raised transition-colors"
                           aria-label={`Open ArduPilot docs for ${param.id}`}

--- a/apps/desktop/src/renderer/components/parameters/ParametersView.tsx
+++ b/apps/desktop/src/renderer/components/parameters/ParametersView.tsx
@@ -5,18 +5,22 @@
  * - MAVLink: ArduPilot config (MavlinkConfigView)
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react';
-import { AlertTriangle, RotateCw, Loader2, Star, Check } from 'lucide-react';
+import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import { AlertTriangle, RotateCw, Loader2, Star, Check, ExternalLink } from 'lucide-react';
 import { useConnectionStore } from '../../stores/connection-store';
 import { useParameterStore, type SortColumn, type FileParamDiff } from '../../stores/parameter-store';
 import { useQuickSetupStore } from '../../stores/quick-setup-store';
 import { useSettingsStore } from '../../stores/settings-store';
 import { NON_DEFAULT_COLORS, getNonDefaultColor } from './non-default-palette';
 import { getParamTypeName, formatParamValue } from '../../../shared/parameter-types';
+import { formatParamDisplayValue } from '../../../shared/param-display';
+import { getParameterDocsUrl, resolveArduPilotDocsContext } from '../../../shared/parameter-metadata';
 import { PARAMETER_GROUPS } from '../../../shared/parameter-groups';
 import { MspConfigView } from './MspConfigView';
 import MavlinkConfigView from '../mavlink-config/MavlinkConfigView';
 import { LegacyConfigView } from '../legacy-config';
+import { ParamNameTooltip } from '../ui/ParamNameTooltip';
+import { Tooltip } from '../ui/Tooltip';
 
 // Simple toast notification state
 type ToastType = 'success' | 'error' | 'info';
@@ -260,7 +264,10 @@ export function ParametersView() {
     }
   }, [connectionState.isConnected, connectionState.isReconnecting, showToast]);
 
-  const handleSaveToFile = useCallback(async (mode: 'all' | 'changed' | 'nondefault') => {
+  const handleSaveToFile = useCallback(async (
+    mode: 'all' | 'changed' | 'nondefault',
+    format: 'mp' | 'qgc' = 'mp',
+  ) => {
     setIsSavingFile(true);
     setSaveDropdownOpen(false);
     try {
@@ -276,7 +283,7 @@ export function ParametersView() {
 
       const params = filtered
         .sort((a, b) => a.id.localeCompare(b.id))
-        .map(p => ({ id: p.id, value: p.value }));
+        .map(p => ({ id: p.id, value: p.value, type: p.type }));
 
       if (params.length === 0) {
         const labels = { all: 'No parameters to save', changed: 'No changed parameters to save', nondefault: 'No non-default parameters to save' };
@@ -285,9 +292,11 @@ export function ParametersView() {
       }
 
       const vehicleType = connectionState.vehicleType || connectionState.fcVariant;
-      const result = await window.electronAPI?.saveParamsToFile(params, vehicleType);
+      const result = await window.electronAPI?.saveParamsToFile(params, vehicleType, { format });
       if (result?.success) {
-        showToast(`Saved ${params.length} parameter${params.length !== 1 ? 's' : ''} to file`, 'success');
+        const actual = result.format ?? format;
+        const fmtLabel = actual === 'qgc' ? 'QGC' : 'MP';
+        showToast(`Saved ${params.length} parameter${params.length !== 1 ? 's' : ''} (${fmtLabel})`, 'success');
       } else if (result?.error && result.error !== 'Cancelled') {
         showToast(result.error, 'error');
       }
@@ -301,8 +310,20 @@ export function ParametersView() {
     try {
       const result = await window.electronAPI?.loadParamsFromFile();
       if (result?.success && result.params) {
+        if (result.params.length === 0) {
+          showToast('No parameters found in file', 'error');
+          return;
+        }
         // Load file params for comparison - do NOT auto-set on vehicle
-        loadFileForCompare(result.params, result.vehicleType);
+        const { diffs, skipped } = loadFileForCompare(result.params, result.vehicleType);
+        if (diffs === 0 && skipped === 0) {
+          showToast('All parameters in file match current values (no differences)', 'info');
+        } else if (diffs === 0 && skipped > 0) {
+          showToast(
+            `No matching parameters to apply (${skipped} name${skipped !== 1 ? 's' : ''} not on vehicle)`,
+            'info',
+          );
+        }
       } else if (result?.error && result.error !== 'Cancelled') {
         showToast(result.error, 'error');
       }
@@ -322,11 +343,11 @@ export function ParametersView() {
 
   // Offline mode handlers
   const handleOpenOfflineFile = useCallback(async () => {
-    const success = await loadOfflineFile();
-    if (!success) {
-      // Cancelled or failed - no toast needed for cancel
-    }
-  }, [loadOfflineFile]);
+    const result = await loadOfflineFile();
+    if (result.success) return;
+    if (result.cancelled) return;
+    showToast(result.error ?? 'Failed to open parameter file', 'error');
+  }, [loadOfflineFile, showToast]);
 
   const handleOfflineSave = useCallback(async () => {
     const success = await saveOfflineFile();
@@ -335,19 +356,60 @@ export function ParametersView() {
     }
   }, [saveOfflineFile, showToast]);
 
-  const handleOfflineSaveAs = useCallback(async () => {
-    const success = await saveOfflineFileAs();
-    if (success) {
-      showToast('Parameters saved to file', 'success');
+  const handleOfflineSaveAs = useCallback(async (format: 'mp' | 'qgc' = 'mp') => {
+    setSaveDropdownOpen(false);
+    const result = await saveOfflineFileAs(format);
+    if (result.success) {
+      const actual = result.format ?? format;
+      const fmtLabel = actual === 'qgc' ? 'QGC' : 'MP';
+      showToast(`Parameters saved (${fmtLabel})`, 'success');
+    } else if (result.error && result.error !== 'Cancelled') {
+      showToast(result.error, 'error');
     }
   }, [saveOfflineFileAs, showToast]);
 
   const handleOfflineCompare = useCallback(async () => {
     const result = await window.electronAPI?.loadParamsFromFile();
     if (result?.success && result.params) {
-      loadFileForCompare(result.params, result.vehicleType);
+      if (result.params.length === 0) {
+        showToast('No parameters found in file', 'error');
+        return;
+      }
+      const { diffs, skipped } = loadFileForCompare(result.params, result.vehicleType);
+      if (diffs === 0 && skipped === 0) {
+        showToast('All parameters in file match current values (no differences)', 'info');
+      } else if (diffs === 0 && skipped > 0) {
+        showToast(
+          `No matching parameters to apply (${skipped} name${skipped !== 1 ? 's' : ''} not on vehicle)`,
+          'info',
+        );
+      }
+    } else if (result?.error && result.error !== 'Cancelled') {
+      showToast(result.error, 'error');
     }
-  }, [loadFileForCompare]);
+  }, [loadFileForCompare, showToast]);
+
+  // ArduPilot docs context for offline/legacy table (same helpers as ParameterTable)
+  const docsContext = useMemo(
+    () =>
+      resolveArduPilotDocsContext({
+        protocol: offlineMode ? undefined : connectionState.protocol,
+        autopilot: offlineMode ? undefined : connectionState.autopilot,
+        mavType: offlineMode ? undefined : connectionState.mavType,
+        vehicleType: connectionState.vehicleType,
+        firmwareVersion: offlineMode ? undefined : connectionState.firmwareVersion,
+        offlineVehicleType: offlineVehicleType ?? undefined,
+      }),
+    [
+      offlineMode,
+      offlineVehicleType,
+      connectionState.protocol,
+      connectionState.autopilot,
+      connectionState.mavType,
+      connectionState.vehicleType,
+      connectionState.firmwareVersion,
+    ],
+  );
 
   const handleSearch = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(e.target.value);
@@ -529,16 +591,45 @@ export function ParametersView() {
               Save
             </button>
 
-            <button
-              onClick={handleOfflineSaveAs}
-              className="px-3 py-2 bg-surface-raised hover:bg-surface-raised text-content rounded-lg text-sm font-medium transition-colors flex items-center gap-2"
-              title="Save to a new file"
-            >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-              </svg>
-              Save As
-            </button>
+            <div className="relative" ref={saveDropdownRef}>
+              <div className="flex">
+                <button
+                  onClick={() => handleOfflineSaveAs('mp')}
+                  className="px-3 py-2 bg-surface-raised hover:bg-surface-raised text-content rounded-l-lg text-sm font-medium transition-colors flex items-center gap-2"
+                  title="Save As Mission Planner .param"
+                >
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  </svg>
+                  Save As
+                </button>
+                <button
+                  onClick={() => setSaveDropdownOpen((prev) => !prev)}
+                  className="px-1.5 py-2 bg-surface-raised hover:bg-surface-raised text-content rounded-r-lg border-l border/30 text-sm transition-colors"
+                  title="Save As options"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                  </svg>
+                </button>
+              </div>
+              {saveDropdownOpen && (
+                <div className="absolute top-full left-0 mt-1 w-64 bg-surface-solid border border-subtle rounded-lg shadow-xl z-50 py-1">
+                  <button
+                    onClick={() => handleOfflineSaveAs('mp')}
+                    className="w-full px-3 py-2 text-left text-sm text-content hover:bg-surface-raised transition-colors"
+                  >
+                    Mission Planner (.param)
+                  </button>
+                  <button
+                    onClick={() => handleOfflineSaveAs('qgc')}
+                    className="w-full px-3 py-2 text-left text-sm text-content hover:bg-surface-raised transition-colors"
+                  >
+                    QGroundControl (.params)
+                  </button>
+                </div>
+              )}
+            </div>
 
             <div className="w-px h-6 bg-surface-raised mx-1" />
 
@@ -599,10 +690,10 @@ export function ParametersView() {
             <div className="relative" ref={saveDropdownRef}>
               <div className="flex">
                 <button
-                  onClick={() => handleSaveToFile('all')}
+                  onClick={() => handleSaveToFile('all', 'mp')}
                   disabled={isSavingFile || paramCount === 0}
                   className="px-3 py-2 bg-surface-raised hover:bg-surface-raised disabled:bg-surface text-content disabled:text-content-tertiary rounded-l-lg text-sm font-medium transition-colors flex items-center gap-2"
-                  title="Save all parameters to file"
+                  title="Save all parameters to Mission Planner .param file"
                 >
                   <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -621,28 +712,51 @@ export function ParametersView() {
                 </button>
               </div>
               {saveDropdownOpen && (
-                <div className="absolute top-full left-0 mt-1 w-56 bg-surface-solid border-subtle rounded-lg shadow-xl z-50 py-1">
+                <div className="absolute top-full left-0 mt-1 w-64 bg-surface-solid border border-subtle rounded-lg shadow-xl z-50 py-1">
                   <button
-                    onClick={() => handleSaveToFile('all')}
+                    onClick={() => handleSaveToFile('all', 'mp')}
                     className="w-full px-3 py-2 text-left text-sm text-content hover:bg-surface-raised transition-colors"
                   >
-                    Save All Parameters
+                    Save All (Mission Planner .param)
                   </button>
                   <button
-                    onClick={() => handleSaveToFile('changed')}
+                    onClick={() => handleSaveToFile('all', 'qgc')}
+                    className="w-full px-3 py-2 text-left text-sm text-content hover:bg-surface-raised transition-colors"
+                  >
+                    Save All (QGroundControl .params)
+                  </button>
+                  <button
+                    onClick={() => handleSaveToFile('changed', 'mp')}
                     disabled={modified === 0}
                     className="w-full px-3 py-2 text-left text-sm text-content hover:bg-surface-raised disabled:text-content-tertiary disabled:hover:bg-transparent transition-colors"
                   >
-                    Save Changed Only
+                    Save Changed Only (.param)
                     {modified > 0 && <span className="ml-1 text-xs text-yellow-400">({modified})</span>}
                   </button>
                   <button
-                    onClick={() => handleSaveToFile('nondefault')}
+                    onClick={() => handleSaveToFile('changed', 'qgc')}
+                    disabled={modified === 0}
+                    className="w-full px-3 py-2 text-left text-sm text-content hover:bg-surface-raised disabled:text-content-tertiary disabled:hover:bg-transparent transition-colors"
+                  >
+                    Save Changed Only (.params)
+                    {modified > 0 && <span className="ml-1 text-xs text-yellow-400">({modified})</span>}
+                  </button>
+                  <button
+                    onClick={() => handleSaveToFile('nondefault', 'mp')}
                     disabled={!hasDefaults}
                     className="w-full px-3 py-2 text-left text-sm text-content hover:bg-surface-raised disabled:text-content-tertiary disabled:hover:bg-transparent transition-colors"
                     title={!hasDefaults ? 'Defaults not available - requires MAVLink FTP' : undefined}
                   >
-                    Save Non-Default Only
+                    Save Non-Default Only (.param)
+                    {hasDefaults && nonDefaultCount > 0 && <span className="ml-1 text-xs text-purple-400">({nonDefaultCount})</span>}
+                  </button>
+                  <button
+                    onClick={() => handleSaveToFile('nondefault', 'qgc')}
+                    disabled={!hasDefaults}
+                    className="w-full px-3 py-2 text-left text-sm text-content hover:bg-surface-raised disabled:text-content-tertiary disabled:hover:bg-transparent transition-colors"
+                    title={!hasDefaults ? 'Defaults not available - requires MAVLink FTP' : undefined}
+                  >
+                    Save Non-Default Only (.params)
                     {hasDefaults && nonDefaultCount > 0 && <span className="ml-1 text-xs text-purple-400">({nonDefaultCount})</span>}
                   </button>
                 </div>
@@ -937,7 +1051,17 @@ export function ParametersView() {
                       >
                         <Star className={`w-3.5 h-3.5 ${isFavourite(param.id) ? 'fill-yellow-400 text-yellow-400' : 'text-content-tertiary hover:text-content-secondary'}`} />
                       </button>
-                      <span className="font-mono text-sm text-content">{param.id}</span>
+                      <ParamNameTooltip
+                        meta={getParameterMetadata(param.id)}
+                        description={getDescription(param.id)}
+                        docUrl={
+                          docsContext
+                            ? getParameterDocsUrl(docsContext.vehicleType, param.id, docsContext.versionTag)
+                            : null
+                        }
+                      >
+                        <span className="font-mono text-sm text-content cursor-help">{param.id}</span>
+                      </ParamNameTooltip>
                       {isRebootRequired(param.id) && (
                         <span className="px-1 py-0.5 text-[9px] leading-none bg-amber-500/15 text-amber-500/70 rounded border-amber-500/20" title="Requires reboot to take effect">
                           Reboot
@@ -949,7 +1073,7 @@ export function ParametersView() {
                     <div className="flex items-center gap-2">
                       {param.isReadOnly ? (
                         <span className="font-mono text-sm text-content-secondary tabular-nums" title="Read-only parameter">
-                          {formatParamValue(param.value)}
+                          {formatParamDisplayValue(param.value, getParameterMetadata(param.id))}
                         </span>
                       ) : editingParam === param.id ? (
                         <div className="relative flex-1">
@@ -975,7 +1099,7 @@ export function ParametersView() {
                       ) : (
                         <button
                           onClick={() => startEdit(param.id, param.value)}
-                          className={`font-mono text-sm ${isNonDefault ? nonDefaultColor.textClass : 'text-content'} hover:text-blue-400 transition-colors tabular-nums`}
+                          className={`font-mono text-sm ${isNonDefault ? nonDefaultColor.textClass : 'text-content'} hover:text-blue-400 transition-colors tabular-nums truncate`}
                           title={(() => {
                             const meta = getParameterMetadata(param.id);
                             const hints: string[] = [];
@@ -988,7 +1112,7 @@ export function ParametersView() {
                             return hints.length > 0 ? hints.join('\n') : undefined;
                           })()}
                         >
-                          {formatParamValue(param.value)}
+                          {formatParamDisplayValue(param.value, getParameterMetadata(param.id))}
                         </button>
                       )}
                       {param.isReadOnly ? (
@@ -1015,16 +1139,39 @@ export function ParametersView() {
                     <span className="text-xs text-content-secondary">{getParamTypeName(param.type)}</span>
                   </td>
                   <td className="px-4 py-2.5">
-                    <span
-                      className={`text-sm line-clamp-2 ${
-                        hasOfficialDescription(param.id)
-                          ? 'text-content-secondary'
-                          : 'text-content-secondary italic'
-                      }`}
-                      title={hasOfficialDescription(param.id) ? undefined : 'Auto-generated description'}
-                    >
-                      {getDescription(param.id)}
-                    </span>
+                    <div className="flex items-start gap-2 min-w-0">
+                      <span
+                        className={`text-sm line-clamp-2 min-w-0 ${
+                          hasOfficialDescription(param.id)
+                            ? 'text-content-secondary'
+                            : 'text-content-secondary italic'
+                        }`}
+                        title={hasOfficialDescription(param.id) ? undefined : 'Auto-generated description'}
+                      >
+                        {getDescription(param.id)}
+                      </span>
+                      {docsContext && (
+                        <Tooltip content="Open ArduPilot docs" placement="top">
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              window.electronAPI?.openExternal(
+                                getParameterDocsUrl(
+                                  docsContext.vehicleType,
+                                  param.id,
+                                  docsContext.versionTag,
+                                ),
+                              );
+                            }}
+                            className="shrink-0 p-1 rounded text-content-tertiary hover:text-blue-400 hover:bg-surface-raised transition-colors"
+                            aria-label={`Open ArduPilot docs for ${param.id}`}
+                          >
+                            <ExternalLink className="w-3.5 h-3.5" />
+                          </button>
+                        </Tooltip>
+                      )}
+                    </div>
                   </td>
                 </tr>
                 );

--- a/apps/desktop/src/renderer/components/ui/ParamNameTooltip.tsx
+++ b/apps/desktop/src/renderer/components/ui/ParamNameTooltip.tsx
@@ -1,0 +1,192 @@
+/**
+ * Hover popover for parameter names: metadata description + optional ArduPilot docs link.
+ * Portalled to document.body so virtualized/scrollable param grids do not clip it.
+ *
+ * Keyboard access for docs intentionally uses the row's dedicated ExternalLink control
+ * (not per-name tab stops). This popover is pointer-oriented: hover to read, click the
+ * docs control inside to open (mousedown preventDefault keeps the panel open).
+ */
+
+import React, { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { ExternalLink } from 'lucide-react';
+
+/** Loose metadata shape — store may return partial definitions. */
+type ParamTooltipMeta = {
+  humanName?: string;
+  description?: string;
+  range?: { min: number; max: number };
+  units?: string;
+  increment?: number;
+  rebootRequired?: boolean;
+};
+
+const VIEWPORT_MARGIN = 8;
+const CLOSE_DELAY_MS = 180;
+
+export function ParamNameTooltip({
+  meta,
+  description,
+  docUrl,
+  docsLinkLabel = 'ArduPilot docs',
+  children,
+}: {
+  meta?: ParamTooltipMeta | null;
+  /** Fallback description when meta is incomplete */
+  description?: string;
+  docUrl?: string | null;
+  docsLinkLabel?: string;
+  children: React.ReactNode;
+}) {
+  const [show, setShow] = useState(false);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tooltipId = useId();
+
+  const humanName = meta?.humanName;
+  const desc = meta?.description || description;
+  const hasMeta = Boolean(humanName || desc || meta?.range || meta?.units || meta?.rebootRequired);
+  const hasContent = hasMeta || Boolean(docUrl);
+
+  const clearCloseTimer = useCallback(() => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleClose = useCallback(() => {
+    clearCloseTimer();
+    closeTimerRef.current = setTimeout(() => setShow(false), CLOSE_DELAY_MS);
+  }, [clearCloseTimer]);
+
+  const open = useCallback(() => {
+    clearCloseTimer();
+    setShow(true);
+  }, [clearCloseTimer]);
+
+  // Prevent setState-after-unmount from the close timer
+  useEffect(() => () => clearCloseTimer(), [clearCloseTimer]);
+
+  // Escape closes while pointer is over the panel or trigger
+  useEffect(() => {
+    if (!show) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        clearCloseTimer();
+        setShow(false);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [show, clearCloseTimer]);
+
+  useLayoutEffect(() => {
+    if (!show || !triggerRef.current) return;
+
+    const update = () => {
+      const trigger = triggerRef.current;
+      const overlay = overlayRef.current;
+      if (!trigger) return;
+      const rect = trigger.getBoundingClientRect();
+      const ow = overlay?.offsetWidth ?? 280;
+      const oh = overlay?.offsetHeight ?? 120;
+      let top = rect.bottom + 4;
+      let left = rect.left;
+      if (top + oh > window.innerHeight - VIEWPORT_MARGIN) {
+        top = Math.max(VIEWPORT_MARGIN, rect.top - oh - 4);
+      }
+      if (left + ow > window.innerWidth - VIEWPORT_MARGIN) {
+        left = Math.max(VIEWPORT_MARGIN, window.innerWidth - VIEWPORT_MARGIN - ow);
+      }
+      if (left < VIEWPORT_MARGIN) left = VIEWPORT_MARGIN;
+      setPos({ top, left });
+    };
+
+    update();
+    const raf = requestAnimationFrame(update);
+    window.addEventListener('scroll', update, true);
+    window.addEventListener('resize', update);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('scroll', update, true);
+      window.removeEventListener('resize', update);
+    };
+  }, [show, meta, docUrl, description]);
+
+  if (!hasContent) {
+    return <>{children}</>;
+  }
+
+  const overlay =
+    show &&
+    typeof document !== 'undefined' &&
+    createPortal(
+      <div
+        ref={overlayRef}
+        id={tooltipId}
+        role="tooltip"
+        className="fixed z-[9999] max-w-[300px] whitespace-normal bg-surface-solid border border-subtle px-2.5 py-2 text-xs leading-relaxed shadow-lg pointer-events-auto rounded"
+        style={pos ? { top: pos.top, left: pos.left } : { top: -9999, left: -9999, visibility: 'hidden' }}
+        onMouseEnter={open}
+        onMouseLeave={scheduleClose}
+      >
+        {humanName && (
+          <div className="font-semibold text-content mb-0.5">{humanName}</div>
+        )}
+        {desc && (
+          <div className="text-content-secondary">{desc}</div>
+        )}
+        {meta?.range && (
+          <div className="text-content-tertiary mt-1">
+            Range: {meta.range.min} &ndash; {meta.range.max}
+            {meta.units ? ` ${meta.units}` : ''}
+          </div>
+        )}
+        {meta?.units && !meta?.range && (
+          <div className="text-content-tertiary mt-1">Units: {meta.units}</div>
+        )}
+        {meta?.increment != null && meta.increment > 0 && (
+          <div className="text-content-tertiary mt-0.5">Step: {meta.increment}</div>
+        )}
+        {meta?.rebootRequired && (
+          <div className="text-amber-400 mt-1">Reboot required after change</div>
+        )}
+        {docUrl && (
+          <button
+            type="button"
+            tabIndex={-1}
+            className="inline-flex items-center gap-1 mt-1.5 text-blue-400 hover:underline focus:outline-none focus-visible:ring-1 focus-visible:ring-blue-400 rounded"
+            // preventDefault keeps the hover bridge alive when clicking (no focus steal/close race)
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={(e) => {
+              e.stopPropagation();
+              window.electronAPI?.openExternal(docUrl);
+            }}
+          >
+            {docsLinkLabel}
+            <ExternalLink className="w-2.5 h-2.5" aria-hidden />
+          </button>
+        )}
+      </div>,
+      document.body,
+    );
+
+  return (
+    <>
+      <span
+        ref={triggerRef}
+        className="inline-flex min-w-0 max-w-full"
+        // Not a tab stop — keyboard users use the row's ExternalLink control for docs.
+        aria-describedby={show ? tooltipId : undefined}
+        onMouseEnter={open}
+        onMouseLeave={scheduleClose}
+      >
+        {children}
+      </span>
+      {overlay}
+    </>
+  );
+}

--- a/apps/desktop/src/renderer/stores/parameter-store.ts
+++ b/apps/desktop/src/renderer/stores/parameter-store.ts
@@ -3,6 +3,7 @@ import type { Parameter, ParameterWithMeta, ParameterProgress, ParamValuePayload
 import { isReadOnlyParameter, generateFallbackDescription } from '../../shared/parameter-types.js';
 import { parameterBelongsToGroup } from '../../shared/parameter-groups.js';
 import { validateParameterValue, vehicleTypeToMavType, type ParameterMetadataStore, type ValidationResult, type VehicleType } from '../../shared/parameter-metadata.js';
+import { offlineParamTypeFromParsed, shouldOpenParamCompareModal } from '../../shared/param-file-parser.js';
 import { createSearchRegex } from '../../shared/search-utils.js';
 
 export type SortColumn = 'name' | 'status';
@@ -95,7 +96,17 @@ interface ParameterStore {
   getDescription: (paramId: string) => string;
   hasOfficialDescription: (paramId: string) => boolean;
   validateParameter: (paramId: string, value: number) => ValidationResult;
-  getParameterMetadata: (paramId: string) => { range?: { min: number; max: number }; values?: Record<number, string>; units?: string; bitmask?: Record<number, string>; rebootRequired?: boolean } | null;
+  getParameterMetadata: (paramId: string) => {
+    name?: string;
+    humanName?: string;
+    description?: string;
+    range?: { min: number; max: number };
+    values?: Record<number, string>;
+    units?: string;
+    bitmask?: Record<number, string>;
+    increment?: number;
+    rebootRequired?: boolean;
+  } | null;
   isRebootRequired: (paramId: string) => boolean;
   isFavourite: (paramId: string) => boolean;
 
@@ -122,15 +133,19 @@ interface ParameterStore {
   reset: () => void;
 
   // Offline mode actions
-  loadOfflineFile: () => Promise<boolean>;
+  loadOfflineFile: () => Promise<{ success: boolean; cancelled?: boolean; error?: string }>;
   saveOfflineFile: () => Promise<boolean>;
-  saveOfflineFileAs: () => Promise<boolean>;
+  saveOfflineFileAs: (format?: 'mp' | 'qgc') => Promise<{ success: boolean; format?: 'mp' | 'qgc'; error?: string }>;
   setOfflineVehicleType: (vehicleType: string) => Promise<void>;
   closeOfflineMode: () => void;
   setOfflineParameter: (paramId: string, value: number) => void;
 
-  // File compare actions
-  loadFileForCompare: (fileParams: Array<{ id: string; value: number }>, fileVehicleType?: string) => void;
+  // File compare actions — returns counts; modal only opens when diffs or skipped remain
+  loadFileForCompare: (fileParams: Array<{ id: string; value: number }>, fileVehicleType?: string) => {
+    diffs: number;
+    skipped: number;
+    total: number;
+  };
   closeCompareModal: () => void;
   toggleDiffSelection: (paramId: string) => void;
   selectAllDiffs: () => void;
@@ -324,10 +339,14 @@ export const useParameterStore = create<ParameterStore>((set, get) => ({
     const meta = metadata?.[paramId];
     if (!meta) return null;
     return {
+      name: meta.name,
+      humanName: meta.humanName,
+      description: meta.description,
       range: meta.range,
       values: meta.values,
       units: meta.units,
       bitmask: meta.bitmask,
+      increment: meta.increment,
       rebootRequired: meta.rebootRequired,
     };
   },
@@ -634,18 +653,30 @@ export const useParameterStore = create<ParameterStore>((set, get) => ({
   // Offline mode actions
   loadOfflineFile: async () => {
     const result = await window.electronAPI?.loadParamsFromFile();
-    if (!result?.success || !result.params) return false;
+    if (!result) {
+      return { success: false, error: 'Parameter load API unavailable' };
+    }
+    if (!result.success) {
+      if (result.error === 'Cancelled') return { success: false, cancelled: true };
+      return { success: false, error: result.error ?? 'Failed to load parameter file' };
+    }
+    if (!result.params || result.params.length === 0) {
+      return {
+        success: false,
+        error: result.error ?? 'No parameters found in file',
+      };
+    }
 
     const filePath = result.filePath ?? null;
     const vehicleType = result.vehicleType ?? null;
 
-    // Build parameter map from file data
+    // Build parameter map from file data (preserve QGC MAV_PARAM_TYPE when present)
     const newParams = new Map<string, ParameterWithMeta>();
     for (const p of result.params) {
       newParams.set(p.id, {
         id: p.id,
         value: p.value,
-        type: 9, // REAL32 - standard ArduPilot param type
+        type: offlineParamTypeFromParsed(p.type) as ParameterWithMeta['type'],
         index: -1,
         originalValue: p.value,
         isModified: false,
@@ -676,14 +707,17 @@ export const useParameterStore = create<ParameterStore>((set, get) => ({
       }
     }
 
-    return true;
+    return { success: true };
   },
 
   saveOfflineFile: async () => {
     const { offlineFilePath, parameters, offlineVehicleType } = get();
-    if (!offlineFilePath) return get().saveOfflineFileAs();
+    if (!offlineFilePath) {
+      const r = await get().saveOfflineFileAs();
+      return r.success;
+    }
 
-    const params = Array.from(parameters.values()).map(p => ({ id: p.id, value: p.value }));
+    const params = Array.from(parameters.values()).map(p => ({ id: p.id, value: p.value, type: p.type }));
     const result = await window.electronAPI?.saveParamsToPath(params, offlineFilePath, offlineVehicleType ?? undefined);
 
     if (result?.success) {
@@ -702,10 +736,14 @@ export const useParameterStore = create<ParameterStore>((set, get) => ({
     return false;
   },
 
-  saveOfflineFileAs: async () => {
+  saveOfflineFileAs: async (format: 'mp' | 'qgc' = 'mp') => {
     const { parameters, offlineVehicleType } = get();
-    const params = Array.from(parameters.values()).map(p => ({ id: p.id, value: p.value }));
-    const result = await window.electronAPI?.saveParamsToFile(params, offlineVehicleType ?? undefined);
+    const params = Array.from(parameters.values()).map(p => ({ id: p.id, value: p.value, type: p.type }));
+    const result = await window.electronAPI?.saveParamsToFile(
+      params,
+      offlineVehicleType ?? undefined,
+      { format },
+    );
 
     if (result?.success && result.filePath) {
       // Update file path and reset modification tracking
@@ -723,9 +761,10 @@ export const useParameterStore = create<ParameterStore>((set, get) => ({
           offlineHasUnsavedChanges: false,
         };
       });
-      return true;
+      return { success: true, format: result.format ?? format };
     }
-    return false;
+    if (result?.error === 'Cancelled') return { success: false, error: 'Cancelled' };
+    return { success: false, error: result?.error ?? 'Failed to save' };
   },
 
   setOfflineVehicleType: async (vehicleType: string) => {
@@ -787,14 +826,21 @@ export const useParameterStore = create<ParameterStore>((set, get) => ({
     // Sort alphabetically
     diffs.sort((a, b) => a.paramId.localeCompare(b.paramId));
 
+    // Open modal only when there are value diffs to review. Skipped-only is toast-only.
     set({
-      showCompareModal: true,
+      showCompareModal: shouldOpenParamCompareModal(diffs.length, skippedList.length),
       fileParamDiffs: diffs,
       fileSkippedParams: skippedList,
       fileSkippedCount: skippedList.length,
       fileTotalCount: fileParams.length,
       fileVehicleType: fileVehicleType ?? null,
     });
+
+    return {
+      diffs: diffs.length,
+      skipped: skippedList.length,
+      total: fileParams.length,
+    };
   },
 
   closeCompareModal: () => {

--- a/apps/desktop/src/shared/ipc-channels.ts
+++ b/apps/desktop/src/shared/ipc-channels.ts
@@ -971,6 +971,11 @@ export interface ConnectionState {
   autopilot?: string;
   vehicleType?: string;
   mavType?: number; // Raw MAV_TYPE for metadata lookup
+  /**
+   * ArduPilot flight software version from AUTOPILOT_VERSION (e.g. "V4.6.3").
+   * Used for versioned parameter documentation links.
+   */
+  firmwareVersion?: string;
   // MSP-specific (Betaflight/iNav)
   fcVariant?: string; // "BTFL", "INAV", "CLFL"
   fcVersion?: string; // "4.5.1"

--- a/apps/desktop/src/shared/param-display.test.ts
+++ b/apps/desktop/src/shared/param-display.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatParamDisplayValue,
+  summarizeBitmask,
+  isIntegerishParamValue,
+  paramValueAsEnumKey,
+} from './param-display';
+import type { ParameterMetadata } from './parameter-metadata';
+
+describe('isIntegerishParamValue / paramValueAsEnumKey', () => {
+  it('accepts clean integers and float32-noisy integers', () => {
+    expect(isIntegerishParamValue(5)).toBe(true);
+    expect(isIntegerishParamValue(Math.fround(5))).toBe(true);
+    // Classic float32 noise around an integer
+    expect(isIntegerishParamValue(5.0000002)).toBe(true);
+    expect(paramValueAsEnumKey(5.0000002)).toBe(5);
+  });
+
+  it('rejects true floats (expo-style)', () => {
+    expect(isIntegerishParamValue(0.135)).toBe(false);
+    expect(isIntegerishParamValue(1.5)).toBe(false);
+  });
+});
+
+describe('formatParamDisplayValue', () => {
+  const meta: ParameterMetadata = {
+    name: 'FLTMODE1',
+    humanName: 'Flight Mode 1',
+    description: '',
+    values: {
+      0: 'Stabilize',
+      5: 'Loiter',
+    },
+  };
+
+  it('shows enum label when known', () => {
+    expect(formatParamDisplayValue(5, meta)).toBe('5 \u2014 Loiter');
+  });
+
+  it('shows enum label under float32 noise', () => {
+    expect(formatParamDisplayValue(5.0000002, meta)).toBe('5 \u2014 Loiter');
+  });
+
+  it('falls back to number when unknown', () => {
+    expect(formatParamDisplayValue(99, meta)).toBe('99');
+  });
+
+  it('returns number without meta', () => {
+    expect(formatParamDisplayValue(1.5)).toBe('1.5');
+  });
+
+  it('summarizes bitmask params', () => {
+    const bm: ParameterMetadata = {
+      name: 'ARMING_CHECK',
+      humanName: 'Arming Check',
+      description: '',
+      bitmask: { 0: 'All', 1: 'Baro', 2: 'Compass' },
+    };
+    expect(formatParamDisplayValue(0, bm)).toBe('0');
+    expect(formatParamDisplayValue(3, bm)).toBe('All, Baro (3)');
+  });
+
+  it('falls through when values map is empty', () => {
+    const empty: ParameterMetadata = {
+      name: 'X',
+      humanName: 'X',
+      description: '',
+      values: {},
+    };
+    expect(formatParamDisplayValue(5, empty)).toBe('5');
+  });
+
+  it('prefers bitmask over values when both are present', () => {
+    const both: ParameterMetadata = {
+      name: 'MIXED',
+      humanName: 'Mixed',
+      description: '',
+      values: { 3: 'ShouldNotShow' },
+      bitmask: { 0: 'All', 1: 'Baro' },
+    };
+    // Product rule: bitmask takes precedence (same as formatParamDisplayValue order)
+    expect(formatParamDisplayValue(3, both)).toBe('All, Baro (3)');
+    expect(formatParamDisplayValue(3, both)).not.toContain('ShouldNotShow');
+  });
+});
+
+describe('summarizeBitmask', () => {
+  it('overflows long flag lists', () => {
+    const bitmask = { 0: 'A', 1: 'B', 2: 'C', 3: 'D' };
+    expect(summarizeBitmask(15, bitmask, 2)).toBe('A, B +2 (15)');
+  });
+
+  it('surfaces unknown set bits', () => {
+    const bitmask = { 0: 'All' };
+    // bit0 + bit3 set → All, bit3
+    expect(summarizeBitmask(0b1001, bitmask)).toBe('All, bit3 (9)');
+  });
+});

--- a/apps/desktop/src/shared/param-display.ts
+++ b/apps/desktop/src/shared/param-display.ts
@@ -1,0 +1,107 @@
+/**
+ * Human-readable parameter value formatting (enums, bitmasks).
+ * Used for non-editing grid/table cells; editors keep select/bitmask/raw controls.
+ */
+
+/** Minimal metadata shape needed for display (matches store partial metadata). */
+export interface ParamDisplayMeta {
+  values?: Record<number, string>;
+  bitmask?: Record<number, string>;
+}
+
+/** Decoded view of a bitmask value. */
+export interface DecodedBitmask {
+  set: string[];
+  unknownBits: number[];
+}
+
+/**
+ * Decode a numeric bitmask value against its bit→label metadata.
+ * Bits set in the value but absent from the metadata are returned in
+ * `unknownBits` so the UI can surface (and never silently drop) them.
+ */
+export function decodeBitmaskFlags(
+  value: number,
+  bitmask: Record<number, string>,
+): DecodedBitmask {
+  const intVal = Math.trunc(value) >>> 0;
+  const set: string[] = [];
+  const entries = Object.entries(bitmask)
+    .map(([k, v]) => [Number(k), v] as const)
+    .sort((a, b) => a[0] - b[0]);
+  for (const [bit, label] of entries) {
+    if (bit >= 0 && bit < 32 && (intVal & (1 << bit)) !== 0) set.push(label);
+  }
+  const known = new Set(entries.map(([b]) => b));
+  const unknownBits: number[] = [];
+  for (let i = 0; i < 32; i++) {
+    if ((intVal & (1 << i)) !== 0 && !known.has(i)) unknownBits.push(i);
+  }
+  return { set, unknownBits };
+}
+
+/**
+ * Compact summary of a bitmask value for a grid cell.
+ * `0` → "0"; few flags → "Label A, Label B (5)"; many → "A, B +3 (255)".
+ */
+export function summarizeBitmask(
+  value: number,
+  bitmask: Record<number, string>,
+  maxLabels = 2,
+): string {
+  const intVal = Math.trunc(value) >>> 0;
+  if (intVal === 0) return '0';
+  const { set, unknownBits } = decodeBitmaskFlags(value, bitmask);
+  const labels = [...set, ...unknownBits.map((b) => `bit${b}`)];
+  if (labels.length === 0) return String(intVal);
+  if (labels.length <= maxLabels) return `${labels.join(', ')} (${intVal})`;
+  const shown = labels.slice(0, maxLabels).join(', ');
+  return `${shown} +${labels.length - maxLabels} (${intVal})`;
+}
+
+/**
+ * True when a MAVLink param value is integer-like after float32 normalization.
+ * Handles classic float32 noise (e.g. 5 stored as 4.999999… / 5.0000002).
+ * Use for enum select gating and enum label display decisions.
+ */
+export function isIntegerishParamValue(value: number): boolean {
+  if (!Number.isFinite(value)) return false;
+  const f = Math.fround(value);
+  return f === Math.fround(Math.round(f));
+}
+
+/** Canonical integer key for enum/bitmask metadata lookup under float32 noise. */
+export function paramValueAsEnumKey(value: number): number {
+  return Math.round(Math.fround(value));
+}
+
+/**
+ * Format a numeric param value for read-only display.
+ * Bitmask params become a decoded summary; enum params become "5 — Loiter";
+ * others return the numeric string (float32-safe).
+ */
+export function formatParamDisplayValue(
+  value: number,
+  meta?: ParamDisplayMeta | null,
+): string {
+  if (meta?.bitmask && Object.keys(meta.bitmask).length > 0) {
+    return summarizeBitmask(value, meta.bitmask);
+  }
+  if (meta?.values && Object.keys(meta.values).length > 0) {
+    const intKey = paramValueAsEnumKey(value);
+    const label =
+      meta.values[value] ??
+      meta.values[intKey] ??
+      meta.values[Math.trunc(value)];
+    if (label !== undefined && isIntegerishParamValue(value)) {
+      return `${intKey} \u2014 ${label}`;
+    }
+    // Non-integer-ish but exact key match (rare float enums)
+    if (label !== undefined && meta.values[value] !== undefined) {
+      return `${parseFloat(value.toPrecision(7))} \u2014 ${label}`;
+    }
+  }
+  if (isIntegerishParamValue(value)) return String(paramValueAsEnumKey(value));
+  if (Number.isInteger(value)) return String(value);
+  return String(parseFloat(value.toPrecision(7)));
+}

--- a/apps/desktop/src/shared/param-file-parser.test.ts
+++ b/apps/desktop/src/shared/param-file-parser.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseParamFile,
+  compareParams,
+  serializeParamFile,
+  buildModifiedFromFile,
+  detectParamFileFormat,
+  extractVehicleTypeFromParamFile,
+  shouldOpenParamCompareModal,
+  offlineParamTypeFromParsed,
+} from './param-file-parser';
+
+describe('parseParamFile', () => {
+  it('parses ArduPilot .param file format (space-separated)', () => {
+    const text = `ARMING_CHECK 1
+BATT_MONITOR 4
+RC1_MIN 1100
+RC1_MAX 1900`;
+    const params = parseParamFile(text);
+    expect(params).toHaveLength(4);
+    expect(params[0]).toEqual({ name: 'ARMING_CHECK', value: 1 });
+    expect(params[1]).toEqual({ name: 'BATT_MONITOR', value: 4 });
+    expect(params[3]).toEqual({ name: 'RC1_MAX', value: 1900 });
+  });
+
+  it('parses comma-separated format', () => {
+    const text = `ARMING_CHECK,1
+BATT_MONITOR,4`;
+    const params = parseParamFile(text);
+    expect(params).toHaveLength(2);
+    expect(params[0]).toEqual({ name: 'ARMING_CHECK', value: 1 });
+  });
+
+  it('skips comment lines starting with #', () => {
+    const text = `# This is a comment
+ARMING_CHECK 1
+# Another comment
+BATT_MONITOR 4`;
+    const params = parseParamFile(text);
+    expect(params).toHaveLength(2);
+  });
+
+  it('handles empty input', () => {
+    expect(parseParamFile('')).toEqual([]);
+  });
+
+  it('skips blank lines', () => {
+    const text = `ARMING_CHECK 1
+
+BATT_MONITOR 4
+
+`;
+    const params = parseParamFile(text);
+    expect(params).toHaveLength(2);
+  });
+
+  it('handles floating point values', () => {
+    const text = `ATC_RAT_RLL_P 0.135
+ATC_RAT_RLL_I 0.135
+ATC_RAT_RLL_D 0.0036`;
+    const params = parseParamFile(text);
+    expect(params).toHaveLength(3);
+    expect(params[0]!.value).toBeCloseTo(0.135);
+    expect(params[2]!.value).toBeCloseTo(0.0036);
+  });
+
+  it('extracts vehicle type from header', () => {
+    const text = `# ArduDeck Parameter File
+# Vehicle: Copter
+ARMING_CHECK,1`;
+    expect(extractVehicleTypeFromParamFile(text)).toBe('Copter');
+  });
+});
+
+describe('compareParams', () => {
+  it('detects changed params', () => {
+    const fileParams = [{ name: 'ARMING_CHECK', value: 0 }];
+    const fcParams = new Map([['ARMING_CHECK', 1]]);
+    const diffs = compareParams(fileParams, fcParams);
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0]!.status).toBe('changed');
+    expect(diffs[0]!.fileValue).toBe(0);
+    expect(diffs[0]!.fcValue).toBe(1);
+  });
+
+  it('detects added params (in file but not on FC)', () => {
+    const fileParams = [{ name: 'NEW_PARAM', value: 42 }];
+    const fcParams = new Map<string, number>();
+    const diffs = compareParams(fileParams, fcParams);
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0]!.status).toBe('added');
+    expect(diffs[0]!.fcValue).toBeNull();
+  });
+
+  it('detects unchanged params', () => {
+    const fileParams = [{ name: 'ARMING_CHECK', value: 1 }];
+    const fcParams = new Map([['ARMING_CHECK', 1]]);
+    const diffs = compareParams(fileParams, fcParams);
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0]!.status).toBe('unchanged');
+  });
+
+  it('sorts results: changed first, then added, then unchanged', () => {
+    const fileParams = [
+      { name: 'UNCHANGED', value: 1 },
+      { name: 'CHANGED', value: 2 },
+      { name: 'ADDED', value: 3 },
+    ];
+    const fcParams = new Map([
+      ['UNCHANGED', 1],
+      ['CHANGED', 99],
+    ]);
+    const diffs = compareParams(fileParams, fcParams);
+    expect(diffs[0]!.status).toBe('changed');
+    expect(diffs[1]!.status).toBe('added');
+    expect(diffs[2]!.status).toBe('unchanged');
+  });
+});
+
+describe('QGC and serialize / buildModified', () => {
+  it('parses QGC 5-column format', () => {
+    const text = `# Onboard parameters
+1\t1\tARMING_CHECK\t1\t9
+1\t1\tBATT_MONITOR\t4\t9`;
+    const params = parseParamFile(text);
+    expect(params).toHaveLength(2);
+    expect(params[0]).toEqual({ name: 'ARMING_CHECK', value: 1, type: 9 });
+  });
+
+  it('skips QGC header lines', () => {
+    const text = `QGC WFW 000\n1 1 FLTMODE1 5 9`;
+    const params = parseParamFile(text);
+    expect(params).toHaveLength(1);
+    expect(params[0]!.name).toBe('FLTMODE1');
+  });
+
+  it('handles BOM and CRLF', () => {
+    const text = '\uFEFFARMING_CHECK 1\r\nBATT_MONITOR 4\r\n';
+    expect(parseParamFile(text)).toHaveLength(2);
+  });
+
+  it('detects formats', () => {
+    expect(detectParamFileFormat('ARMING_CHECK 1')).toBe('mp');
+    expect(detectParamFileFormat('QGC WFW 000\n1 1 FLTMODE1 5 9')).toBe('qgc');
+    expect(detectParamFileFormat('# only comments')).toBe('unknown');
+  });
+
+  it('round-trips MP serialize', () => {
+    const rows = [{ name: 'ARMING_CHECK', value: 1 }, { name: 'WP_SPEED', value: 5.5 }];
+    const text = serializeParamFile(rows, { format: 'mp' });
+    const parsed = parseParamFile(text);
+    expect(parsed).toEqual([
+      { name: 'ARMING_CHECK', value: 1 },
+      { name: 'WP_SPEED', value: 5.5 },
+    ]);
+  });
+
+  it('round-trips QGC serialize including type', () => {
+    const rows = [
+      { name: 'ARMING_CHECK', value: 1, type: 6 },
+      { name: 'WP_SPEED', value: 5.5, type: 9 },
+    ];
+    const text = serializeParamFile(rows, { format: 'qgc', systemId: 1, componentId: 1 });
+    const parsed = parseParamFile(text);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0]).toEqual({ name: 'ARMING_CHECK', value: 1, type: 6 });
+    expect(parsed[1]).toEqual({ name: 'WP_SPEED', value: 5.5, type: 9 });
+  });
+
+  it('buildModifiedFromFile sets and clears modifications', () => {
+    const fc = new Map([['ARMING_CHECK', 1], ['FLTMODE1', 0]]);
+    const r1 = buildModifiedFromFile([{ name: 'ARMING_CHECK', value: 2 }], fc);
+    expect(r1.modified.get('ARMING_CHECK')).toBe(2);
+    expect(r1.applied).toBe(1);
+    const r2 = buildModifiedFromFile([{ name: 'ARMING_CHECK', value: 1 }], fc, r1.modified);
+    expect(r2.modified.has('ARMING_CHECK')).toBe(false);
+  });
+
+  it('buildModifiedFromFile counts unknown names', () => {
+    const fc = new Map([['ARMING_CHECK', 1]]);
+    const r = buildModifiedFromFile([{ name: 'NOT_ON_FC', value: 9 }], fc);
+    expect(r.unknown).toBe(1);
+    expect(r.applied).toBe(0);
+  });
+
+  it('treats float32 noise as unchanged (f32-aware equality)', () => {
+    // Guaranteed same float32: both sides from Math.fround of the same logical value,
+    // plus a double that differs in lower bits but frounds to the same f32.
+    const logical = 0.135;
+    const fcVal = Math.fround(logical);
+    // Construct a double that is not === fcVal but shares the same float32.
+    const noisyDouble = fcVal + Number.EPSILON * 8;
+    expect(Math.fround(noisyDouble)).toBe(fcVal); // precondition always enforced
+    expect(noisyDouble === fcVal).toBe(false); // would false-positive with strict !==
+
+    const fc = new Map([['ATC_RAT_RLL_P', fcVal]]);
+    const diffs = compareParams([{ name: 'ATC_RAT_RLL_P', value: noisyDouble }], fc);
+    expect(diffs[0]!.status).toBe('unchanged');
+    const mod = buildModifiedFromFile([{ name: 'ATC_RAT_RLL_P', value: noisyDouble }], fc);
+    expect(mod.modified.has('ATC_RAT_RLL_P')).toBe(false);
+  });
+
+  it('detects real float changes even with f32 equality', () => {
+    const fc = new Map([['ATC_RAT_RLL_P', 0.135]]);
+    const diffs = compareParams([{ name: 'ATC_RAT_RLL_P', value: 0.2 }], fc);
+    expect(diffs[0]!.status).toBe('changed');
+  });
+
+  it('shouldOpenParamCompareModal only for value diffs', () => {
+    expect(shouldOpenParamCompareModal(0, 0)).toBe(false);
+    expect(shouldOpenParamCompareModal(0, 5)).toBe(false); // skipped-only → toast, no modal
+    expect(shouldOpenParamCompareModal(3, 0)).toBe(true);
+    expect(shouldOpenParamCompareModal(2, 10)).toBe(true);
+  });
+
+  it('offlineParamTypeFromParsed defaults REAL32 and preserves QGC types', () => {
+    expect(offlineParamTypeFromParsed(undefined)).toBe(9);
+    expect(offlineParamTypeFromParsed(6)).toBe(6);
+  });
+
+  it('skips // and ; comment styles and inline comments', () => {
+    const text = `// header
+; another
+ARMING_CHECK 1 # inline
+BATT_MONITOR 4 // tail
+`;
+    expect(parseParamFile(text)).toEqual([
+      { name: 'ARMING_CHECK', value: 1 },
+      { name: 'BATT_MONITOR', value: 4 },
+    ]);
+  });
+
+  it('rejects invalid parameter names', () => {
+    const text = `123BAD 1
+_LEADING 2
+GOOD_PARAM 3
+`;
+    const params = parseParamFile(text);
+    expect(params).toHaveLength(1);
+    expect(params[0]!.name).toBe('GOOD_PARAM');
+  });
+
+  it('returns empty for unrecognized content', () => {
+    expect(parseParamFile('not a param file at all\n!!!')).toEqual([]);
+    expect(detectParamFileFormat('not a param file')).toBe('unknown');
+  });
+
+  it('preserves QGC type through parse for offline type round-trip', () => {
+    const text = `1\t1\tARMING_CHECK\t1\t6
+1\t1\tWP_SPEED\t5.5\t9`;
+    const params = parseParamFile(text);
+    expect(params[0]).toEqual({ name: 'ARMING_CHECK', value: 1, type: 6 });
+    expect(params[1]!.type).toBe(9);
+    // Simulate offline store mapping: type from file or REAL32 default
+    const offlineTypes = params.map((p) => p.type ?? 9);
+    expect(offlineTypes).toEqual([6, 9]);
+  });
+});

--- a/apps/desktop/src/shared/param-file-parser.ts
+++ b/apps/desktop/src/shared/param-file-parser.ts
@@ -1,0 +1,278 @@
+/**
+ * Parse/serialize Mission Planner .param and QGroundControl .params files
+ * and compare against FC parameters.
+ */
+
+export interface ParsedParam {
+  name: string;
+  value: number;
+  /** MAV_PARAM_TYPE when known (QGC 5th column). */
+  type?: number;
+}
+
+export interface ParamDiff {
+  name: string;
+  fileValue: number;
+  fcValue: number | null;
+  status: 'changed' | 'added' | 'unchanged';
+}
+
+export type ParamFileFormat = 'mp' | 'qgc' | 'unknown';
+
+export interface SerializeParamOptions {
+  format: 'mp' | 'qgc';
+  systemId?: number;
+  componentId?: number;
+  /** Fallback MAV_PARAM_TYPE for QGC export when not provided per-param. Default 9 (REAL32). */
+  defaultType?: number;
+  /** Optional header comment lines (without leading #). */
+  headerComments?: string[];
+}
+
+export interface BuildModifiedResult {
+  modified: Map<string, number>;
+  applied: number;
+  unknown: number;
+}
+
+const PARAM_NAME_RE = /^[A-Za-z][A-Za-z0-9_]*$/;
+
+function normalizeText(text: string): string {
+  return text.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+function isCommentOrHeader(line: string): boolean {
+  const t = line.trim();
+  if (!t) return true;
+  if (t.startsWith('#') || t.startsWith('//') || t.startsWith(';')) return true;
+  const low = t.toLowerCase();
+  if (low.startsWith('qgc')) return true;
+  if (low === 'vehicle_id' || low.startsWith('vehicle_id ')) return true;
+  return false;
+}
+
+function stripInlineComment(line: string): string {
+  let out = line;
+  for (const sep of ['#', '//', ';']) {
+    const idx = out.indexOf(sep);
+    if (idx !== -1) out = out.slice(0, idx);
+  }
+  return out.trim();
+}
+
+/** Heuristic format detection for operator feedback / future UI. */
+export function detectParamFileFormat(text: string): ParamFileFormat {
+  const lines = normalizeText(text).split('\n');
+  let qgcHits = 0;
+  let mpHits = 0;
+  for (const raw of lines) {
+    if (isCommentOrHeader(raw)) {
+      if (raw.trim().toLowerCase().startsWith('qgc')) return 'qgc';
+      continue;
+    }
+    const line = stripInlineComment(raw);
+    if (!line) continue;
+    const parts = line.split(/[\s,]+/).filter(Boolean);
+    if (parts.length >= 5) {
+      const a = parseInt(parts[0]!, 10);
+      const b = parseInt(parts[1]!, 10);
+      if (!isNaN(a) && !isNaN(b) && PARAM_NAME_RE.test(parts[2]!)) {
+        qgcHits++;
+        continue;
+      }
+    }
+    if (
+      parts.length >= 2 &&
+      PARAM_NAME_RE.test(parts[0]!) &&
+      !isNaN(parseFloat(parts[1]!))
+    ) {
+      mpHits++;
+    }
+  }
+  if (qgcHits > 0 && qgcHits >= mpHits) return 'qgc';
+  if (mpHits > 0) return 'mp';
+  return 'unknown';
+}
+
+/**
+ * Extract vehicle type from ArduDeck / comment headers (`# Vehicle: Copter`).
+ */
+export function extractVehicleTypeFromParamFile(text: string): string | undefined {
+  for (const raw of normalizeText(text).split('\n')) {
+    const trimmed = raw.trim();
+    if (!trimmed.startsWith('#')) continue;
+    const vehicleMatch = trimmed.match(/^#\s*Vehicle:\s*(.+)/i);
+    if (vehicleMatch?.[1]) return vehicleMatch[1].trim();
+  }
+  return undefined;
+}
+
+/**
+ * Parse a .param / .params file into name/value pairs.
+ * Supports Mission Planner (NAME VALUE / NAME,VALUE) and QGC
+ * (VEHICLE_ID COMPONENT_ID NAME VALUE TYPE).
+ */
+export function parseParamFile(text: string): ParsedParam[] {
+  const params: ParsedParam[] = [];
+  for (const raw of normalizeText(text).split('\n')) {
+    if (isCommentOrHeader(raw)) continue;
+    const line = stripInlineComment(raw);
+    if (!line) continue;
+
+    const parts =
+      line.includes(',') && !line.includes(' ')
+        ? line.split(',').map((p) => p.trim()).filter(Boolean)
+        : line.split(/[\s,]+/).filter(Boolean);
+
+    if (parts.length < 2) continue;
+
+    // QGC: sysid compid NAME VALUE [TYPE]
+    if (parts.length >= 5) {
+      const sys = parseInt(parts[0]!, 10);
+      const comp = parseInt(parts[1]!, 10);
+      const maybeName = parts[2]!;
+      const maybeVal = parseFloat(parts[3]!);
+      if (!isNaN(sys) && !isNaN(comp) && PARAM_NAME_RE.test(maybeName) && !isNaN(maybeVal)) {
+        const typeNum = parseInt(parts[4]!, 10);
+        params.push({
+          name: maybeName,
+          value: maybeVal,
+          type: !isNaN(typeNum) ? typeNum : undefined,
+        });
+        continue;
+      }
+    }
+
+    // MP / generic: NAME VALUE
+    const name = parts[0]!.replace(/"/g, '');
+    const value = parseFloat(parts[1]!);
+    if (PARAM_NAME_RE.test(name) && !isNaN(value)) {
+      params.push({ name, value });
+    }
+  }
+  return params;
+}
+
+function formatParamFileValue(value: number): string {
+  if (Number.isInteger(value)) return String(value);
+  // float32 noise: recover ~6 significant digits for file interchange
+  return String(parseFloat(value.toPrecision(6)));
+}
+
+/** Serialize parameters for download / save dialogs. */
+export function serializeParamFile(
+  rows: Array<{ name: string; value: number; type?: number }>,
+  options: SerializeParamOptions,
+): string {
+  const sys = options.systemId ?? 1;
+  const comp = options.componentId ?? 1;
+  const defaultType = options.defaultType ?? 9;
+
+  if (options.format === 'qgc') {
+    const header = options.headerComments?.length
+      ? options.headerComments.map((c) => (c.startsWith('#') ? c : `# ${c}`))
+      : ['# Onboard parameters', '# VEHICLE_ID COMPONENT_ID NAME VALUE TYPE'];
+    const lines = [
+      ...header,
+      ...rows.map(
+        (r) =>
+          `${sys}\t${comp}\t${r.name}\t${formatParamFileValue(r.value)}\t${r.type ?? defaultType}`,
+      ),
+    ];
+    return lines.join('\n') + '\n';
+  }
+
+  // Mission Planner / ArduDeck .param — comma form is widely compatible
+  const header = options.headerComments?.length
+    ? options.headerComments.map((c) => (c.startsWith('#') ? c : `# ${c}`)).join('\n') + '\n\n'
+    : '';
+  if (rows.length === 0) return header;
+  return (
+    header +
+    rows.map((r) => `${r.name},${formatParamFileValue(r.value)}`).join('\n') +
+    '\n'
+  );
+}
+
+/**
+ * Float32-aware equality for MAVLink REAL32 params (matches parameter-store f32Equal).
+ * Avoids false "changed" diffs from float64 noise after float32 round-trips.
+ */
+export function paramValuesEqual(a: number, b: number): boolean {
+  return Math.fround(a) === Math.fround(b);
+}
+
+/**
+ * Whether the parameter compare modal should open after loading a file.
+ * Only open when there are value diffs to review; skipped-only is toast-only.
+ */
+export function shouldOpenParamCompareModal(diffCount: number, _skippedCount = 0): boolean {
+  return diffCount > 0;
+}
+
+/**
+ * Offline parameter type for a parsed row: preserve QGC type when present, else REAL32 (9).
+ */
+export function offlineParamTypeFromParsed(type: number | undefined): number {
+  return type ?? 9;
+}
+
+/**
+ * Compare file params against current FC params.
+ * Returns a diff array sorted by status (changed first, then added, then unchanged).
+ * Uses float32-aware equality so IEEE noise does not create spurious changes.
+ */
+export function compareParams(
+  fileParams: ParsedParam[],
+  fcParams: Map<string, number>,
+): ParamDiff[] {
+  const diffs: ParamDiff[] = [];
+
+  for (const fp of fileParams) {
+    const fcValue = fcParams.get(fp.name);
+    if (fcValue === undefined) {
+      diffs.push({ name: fp.name, fileValue: fp.value, fcValue: null, status: 'added' });
+    } else if (!paramValuesEqual(fcValue, fp.value)) {
+      diffs.push({ name: fp.name, fileValue: fp.value, fcValue, status: 'changed' });
+    } else {
+      diffs.push({ name: fp.name, fileValue: fp.value, fcValue, status: 'unchanged' });
+    }
+  }
+
+  const order: Record<string, number> = { changed: 0, added: 1, unchanged: 2 };
+  diffs.sort((a, b) => {
+    const o = order[a.status]! - order[b.status]!;
+    if (o !== 0) return o;
+    return a.name.localeCompare(b.name);
+  });
+
+  return diffs;
+}
+
+/**
+ * Apply a parsed file onto the FC parameter list as a pending modified map.
+ * Only names present on the FC are applied; unknown names are counted separately.
+ * Uses float32-aware equality when deciding modified vs clear.
+ */
+export function buildModifiedFromFile(
+  parsed: ParsedParam[],
+  fcParams: Map<string, number>,
+  existingModified: Map<string, number> = new Map(),
+): BuildModifiedResult {
+  const modified = new Map(existingModified);
+  let applied = 0;
+  let unknown = 0;
+
+  for (const p of parsed) {
+    const fcValue = fcParams.get(p.name);
+    if (fcValue === undefined) {
+      unknown++;
+      continue;
+    }
+    applied++;
+    if (!paramValuesEqual(fcValue, p.value)) modified.set(p.name, p.value);
+    else modified.delete(p.name);
+  }
+
+  return { modified, applied, unknown };
+}

--- a/apps/desktop/src/shared/parameter-metadata.test.ts
+++ b/apps/desktop/src/shared/parameter-metadata.test.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import {
   validateParameterValue,
+  getParameterDocsUrl,
+  parseFirmwareVersionTag,
+  paramNameToDocFragment,
+  vehicleTypeToDocsSlug,
+  vehicleTypeToDocsTitle,
+  resolveArduPilotDocsContext,
+  vehicleNameToVehicleType,
+  firmwareVersionTagFromFlightSwVersion,
+  packFlightSwVersion,
+  FIRMWARE_VERSION_TYPE_OFFICIAL,
   type ParameterMetadata,
 } from './parameter-metadata';
 
@@ -158,5 +168,185 @@ describe('parseParameterXml value regex - negative code support', () => {
     const xml = '<value code="-1">GPIO</value>';
     const match = oldValueRegex.exec(xml);
     expect(match).toBeNull(); // Old regex cannot match negative codes
+  });
+});
+
+describe('vehicleTypeToDocsSlug / vehicleTypeToDocsTitle', () => {
+  it('maps all ArduPilot vehicles including tracker → antennatracker', () => {
+    expect(vehicleTypeToDocsSlug('copter')).toBe('copter');
+    expect(vehicleTypeToDocsSlug('plane')).toBe('plane');
+    expect(vehicleTypeToDocsSlug('rover')).toBe('rover');
+    expect(vehicleTypeToDocsSlug('sub')).toBe('sub');
+    expect(vehicleTypeToDocsSlug('tracker')).toBe('antennatracker');
+    expect(vehicleTypeToDocsTitle('copter')).toBe('Copter');
+    expect(vehicleTypeToDocsTitle('tracker')).toBe('AntennaTracker');
+  });
+});
+
+describe('parseFirmwareVersionTag', () => {
+  it('parses V-prefixed three-part semver', () => {
+    expect(parseFirmwareVersionTag('ArduCopter V4.6.3')).toBe('V4.6.3');
+  });
+
+  it('parses plain three-part semver', () => {
+    expect(parseFirmwareVersionTag('APM:Copter 4.5.7')).toBe('V4.5.7');
+  });
+
+  it('returns null for two-part versions (Sphinx pages need full V*.*.*)', () => {
+    expect(parseFirmwareVersionTag('V4.6')).toBeNull();
+    expect(parseFirmwareVersionTag('Copter 4.6')).toBeNull();
+  });
+
+  it('returns null for pre-release / custom builds', () => {
+    expect(parseFirmwareVersionTag('ArduCopter V4.6.3-dev')).toBeNull();
+    expect(parseFirmwareVersionTag('4.5.7-rc1')).toBeNull();
+    expect(parseFirmwareVersionTag('custom-build-xyz')).toBeNull();
+    expect(parseFirmwareVersionTag('beta 4.5.7')).toBeNull();
+  });
+
+  it('returns null when unparseable (caller uses parameters.html)', () => {
+    expect(parseFirmwareVersionTag('')).toBeNull();
+    expect(parseFirmwareVersionTag(null)).toBeNull();
+  });
+});
+
+describe('paramNameToDocFragment', () => {
+  it('lowercases and hyphenates underscores', () => {
+    expect(paramNameToDocFragment('AHRS_GPS_MINSATS')).toBe('ahrs-gps-minsats');
+    expect(paramNameToDocFragment('ARMING_CHECK')).toBe('arming-check');
+  });
+});
+
+describe('getParameterDocsUrl', () => {
+  it('builds versioned URL with hyphenated fragment', () => {
+    const url = getParameterDocsUrl('copter', 'AHRS_GPS_MINSATS', 'V4.5.7');
+    expect(url).toBe(
+      'https://ardupilot.org/copter/docs/parameters-Copter-stable-V4.5.7.html#ahrs-gps-minsats',
+    );
+  });
+
+  it('uses unversioned parameters.html when version unknown', () => {
+    const url = getParameterDocsUrl('plane', 'FLTMODE1', null);
+    expect(url).toBe('https://ardupilot.org/plane/docs/parameters.html#fltmode1');
+  });
+
+  it('never emits parameters-*-stable-latest.html', () => {
+    const url = getParameterDocsUrl('copter', 'ARMING_CHECK', 'latest');
+    expect(url).not.toContain('stable-latest');
+    expect(url).toContain('/parameters.html#arming-check');
+  });
+
+  it('falls back to unversioned for incomplete version tags', () => {
+    const url = getParameterDocsUrl('copter', 'ARMING_CHECK', 'V4.6');
+    expect(url).toBe('https://ardupilot.org/copter/docs/parameters.html#arming-check');
+  });
+
+  it('uses antennatracker path for tracker', () => {
+    const url = getParameterDocsUrl('tracker', 'SERVO1_FUNCTION', null);
+    expect(url).toContain('/antennatracker/docs/parameters.html#');
+  });
+});
+
+describe('resolveArduPilotDocsContext', () => {
+  it('resolves ArduPilot copter with firmware version', () => {
+    const ctx = resolveArduPilotDocsContext({
+      protocol: 'mavlink',
+      autopilot: 'ArduPilot',
+      mavType: 2,
+      firmwareVersion: 'V4.6.3',
+    });
+    expect(ctx?.vehicleType).toBe('copter');
+    expect(ctx?.versionTag).toBe('V4.6.3');
+  });
+
+  it('returns null for msp', () => {
+    expect(
+      resolveArduPilotDocsContext({
+        protocol: 'msp',
+        autopilot: 'BTFL',
+        vehicleType: 'copter',
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null for non-ArduPilot mavlink autopilot', () => {
+    expect(
+      resolveArduPilotDocsContext({
+        protocol: 'mavlink',
+        autopilot: 'PX4',
+        mavType: 2,
+        firmwareVersion: 'v1.15.0',
+      }),
+    ).toBeNull();
+  });
+
+  it('falls back to offline vehicle type without live autopilot', () => {
+    const ctx = resolveArduPilotDocsContext({
+      offlineVehicleType: 'Copter',
+    });
+    expect(ctx?.vehicleType).toBe('copter');
+    expect(ctx?.versionTag).toBeNull();
+  });
+
+  it('prefers offline vehicle type over stale live vehicleType', () => {
+    const ctx = resolveArduPilotDocsContext({
+      vehicleType: 'Plane',
+      offlineVehicleType: 'Rover',
+    });
+    expect(ctx?.vehicleType).toBe('rover');
+  });
+
+  it('returns null for non-ArduPilot offline labels', () => {
+    expect(
+      resolveArduPilotDocsContext({ offlineVehicleType: 'BTFL' }),
+    ).toBeNull();
+    expect(
+      resolveArduPilotDocsContext({ offlineVehicleType: 'PX4' }),
+    ).toBeNull();
+  });
+
+  it('rejects non-ArduPilot autopilot even without protocol', () => {
+    expect(
+      resolveArduPilotDocsContext({
+        autopilot: 'PX4',
+        mavType: 2,
+        vehicleType: 'Quadrotor',
+      }),
+    ).toBeNull();
+  });
+
+  it('rejects bare vehicleType without AP context signal', () => {
+    expect(
+      resolveArduPilotDocsContext({ vehicleType: 'Copter' }),
+    ).toBeNull();
+  });
+});
+
+describe('vehicleNameToVehicleType', () => {
+  it('maps MAV type display names used in headers', () => {
+    expect(vehicleNameToVehicleType('Quadrotor')).toBe('copter');
+    expect(vehicleNameToVehicleType('Hexarotor')).toBe('copter');
+    expect(vehicleNameToVehicleType('Octorotor')).toBe('copter');
+    expect(vehicleNameToVehicleType('Fixed Wing')).toBe('plane');
+    expect(vehicleNameToVehicleType('Ground Rover')).toBe('rover');
+    expect(vehicleNameToVehicleType('Antenna Tracker')).toBe('tracker');
+  });
+});
+
+describe('firmwareVersionTagFromFlightSwVersion (vType packing)', () => {
+  it('emits Vmajor.minor.patch only for official/stable type 255', () => {
+    const official = packFlightSwVersion(4, 6, 3, FIRMWARE_VERSION_TYPE_OFFICIAL);
+    expect(firmwareVersionTagFromFlightSwVersion(official)).toBe('V4.6.3');
+  });
+
+  it('returns undefined for dev/beta/rc type bytes', () => {
+    expect(firmwareVersionTagFromFlightSwVersion(packFlightSwVersion(4, 6, 3, 0))).toBeUndefined(); // dev
+    expect(firmwareVersionTagFromFlightSwVersion(packFlightSwVersion(4, 6, 3, 64))).toBeUndefined(); // alpha
+    expect(firmwareVersionTagFromFlightSwVersion(packFlightSwVersion(4, 6, 3, 128))).toBeUndefined(); // beta
+    expect(firmwareVersionTagFromFlightSwVersion(packFlightSwVersion(4, 6, 3, 192))).toBeUndefined(); // rc
+  });
+
+  it('returns undefined for zero / invalid packed values', () => {
+    expect(firmwareVersionTagFromFlightSwVersion(0)).toBeUndefined();
   });
 });

--- a/apps/desktop/src/shared/parameter-metadata.ts
+++ b/apps/desktop/src/shared/parameter-metadata.ts
@@ -44,11 +44,286 @@ const DOCS_SLUG: Record<VehicleType, string> = {
   tracker: 'antennatracker',
 };
 
-export function getParameterDocsUrl(vehicleType: VehicleType, paramId: string): string {
-  // Anchor format on ardupilot.org: lowercased with underscores → hyphens.
-  // e.g. ACRO_RP_RATE_TC → #acro-rp-rate-tc
-  const anchor = paramId.toLowerCase().replace(/_/g, '-');
-  return `https://ardupilot.org/${DOCS_SLUG[vehicleType]}/docs/parameters.html#${anchor}`;
+/** Title-case segment used in parameters-*-stable-V*.html filenames. */
+const DOCS_TITLE: Record<VehicleType, string> = {
+  copter: 'Copter',
+  plane: 'Plane',
+  rover: 'Rover',
+  sub: 'Sub',
+  tracker: 'AntennaTracker',
+};
+
+/** Map vehicle type to ardupilot.org path segment. */
+export function vehicleTypeToDocsSlug(vehicleType: VehicleType): string {
+  return DOCS_SLUG[vehicleType];
+}
+
+/** Title-case vehicle name for versioned parameter doc filenames. */
+export function vehicleTypeToDocsTitle(vehicleType: VehicleType): string {
+  return DOCS_TITLE[vehicleType];
+}
+
+/**
+ * Sphinx/RTD section id for a param on ardupilot.org parameter pages.
+ * `AHRS_GPS_MINSATS` → `ahrs-gps-minsats`
+ */
+export function paramNameToDocFragment(paramId: string): string {
+  return paramId.trim().toLowerCase().replace(/_/g, '-');
+}
+
+/**
+ * True when a version string looks like a stable release suitable for Sphinx
+ * `parameters-*-stable-V*.*.*.html` pages (full three-part semver, not pre-release).
+ */
+export function isStableDocsVersionTag(tag: string): boolean {
+  // Sphinx stable pages use full Vmajor.minor.patch (e.g. V4.5.7). Two-part
+  // tags (V4.6) and pre-release markers commonly 404.
+  return /^V\d+\.\d+\.\d+$/i.test(tag.trim());
+}
+
+/**
+ * MAVLink AUTOPILOT_VERSION firmware type byte: official/stable release.
+ * @see https://mavlink.io/en/messages/common.html#FIRMWARE_VERSION_TYPE
+ */
+export const FIRMWARE_VERSION_TYPE_OFFICIAL = 255;
+
+/**
+ * Derive a docs-facing firmware version tag from the packed AUTOPILOT_VERSION
+ * `flight_sw_version` field (major|minor|patch|type as big-endian u32 layout on wire,
+ * decoded LE in host view the same way ArduDeck main process does).
+ *
+ * Only official/stable (type byte 255) yields a tag for versioned Sphinx pages;
+ * dev/beta/rc return undefined so callers use unversioned parameters.html.
+ */
+export function firmwareVersionTagFromFlightSwVersion(
+  flightSwVersion: number,
+): string | undefined {
+  if (!flightSwVersion || flightSwVersion <= 0) return undefined;
+  const major = (flightSwVersion >>> 24) & 0xff;
+  const minor = (flightSwVersion >>> 16) & 0xff;
+  const patch = (flightSwVersion >>> 8) & 0xff;
+  const vType = flightSwVersion & 0xff;
+  if (vType !== FIRMWARE_VERSION_TYPE_OFFICIAL) return undefined;
+  const tag = `V${major}.${minor}.${patch}`;
+  return isStableDocsVersionTag(tag) ? tag : undefined;
+}
+
+/** Pack major.minor.patch + type into the AUTOPILOT_VERSION flight_sw_version layout (for tests). */
+export function packFlightSwVersion(
+  major: number,
+  minor: number,
+  patch: number,
+  vType: number,
+): number {
+  return (
+    ((major & 0xff) << 24) |
+    ((minor & 0xff) << 16) |
+    ((patch & 0xff) << 8) |
+    (vType & 0xff)
+  ) >>> 0;
+}
+
+/**
+ * Extract a stable version tag (e.g. V4.6.3) from AUTOPILOT_VERSION / display strings.
+ * Returns null when no stable three-part semver is present (caller uses unversioned parameters.html).
+ *
+ * Note: ardupilot.org has no `parameters-*-stable-latest.html` page — only specific V*.*.*
+ * builds or the live `parameters.html` index. Dev/beta/rc strings intentionally return null.
+ */
+export function parseFirmwareVersionTag(
+  firmwareVersionString: string | undefined | null,
+): string | null {
+  if (!firmwareVersionString || !firmwareVersionString.trim()) return null;
+  const s = firmwareVersionString.trim();
+
+  // Pre-release / custom builds: force unversioned parameters.html (Sphinx stable pages 404)
+  if (/\b(dev|alpha|beta|rc\d*|devel|custom)\b/i.test(s)) return null;
+  if (/V?\d+\.\d+\.\d+[-+][A-Za-z0-9]/i.test(s)) return null; // e.g. 4.5.7-dev, V4.6.0-rc1
+
+  // Prefer explicit V-prefixed full three-part semver (ArduCopter V4.6.3)
+  const vPrefixed = s.match(/\bV(\d+\.\d+\.\d+)\b/i);
+  if (vPrefixed) return `V${vPrefixed[1]}`;
+
+  // Plain three-part semver (APM:Copter 4.5.7). Require patch — V4.6 alone is not a Sphinx page.
+  const plain = s.match(/(?:^|[\s:])(\d+\.\d+\.\d+)(?:\b|$)/);
+  if (plain) return `V${plain[1]}`;
+
+  return null;
+}
+
+/**
+ * Official ArduPilot parameter docs URL for a single parameter.
+ *
+ * Versioned (when known stable): `…/parameters-Copter-stable-V4.5.7.html#ahrs-gps-minsats`
+ * Fallback (dev / unknown / incomplete version): `…/parameters.html#ahrs-gps-minsats`
+ *
+ * @param versionTag Optional firmware version (e.g. "V4.5.7", "4.5.7"). Pass null/omit for unversioned.
+ */
+export function getParameterDocsUrl(
+  vehicleType: VehicleType,
+  paramId: string,
+  versionTag: string | null = null,
+): string {
+  const slug = DOCS_SLUG[vehicleType];
+  const title = DOCS_TITLE[vehicleType];
+  const fragment = paramNameToDocFragment(paramId);
+
+  // Never emit parameters-*-stable-latest.html — only specific V*.*.* or unversioned parameters.html
+  let ver: string | null = null;
+  if (versionTag && versionTag !== 'latest') {
+    const normalized = versionTag.startsWith('V') || versionTag.startsWith('v')
+      ? `V${versionTag.slice(1)}`
+      : `V${versionTag}`;
+    if (isStableDocsVersionTag(normalized)) ver = normalized;
+  }
+
+  if (ver) {
+    return `https://ardupilot.org/${slug}/docs/parameters-${title}-stable-${ver}.html#${fragment}`;
+  }
+  return `https://ardupilot.org/${slug}/docs/parameters.html#${fragment}`;
+}
+
+/**
+ * Resolve ArduPilot docs vehicle + version from connection/offline context.
+ * Returns null for non-ArduPilot (MSP, PX4, unknown) so UI can hide docs links.
+ */
+function isArduPilotAutopilotLabel(autopilot: string | null | undefined): boolean {
+  if (!autopilot) return false;
+  return /ardupilot/i.test(autopilot);
+}
+
+function isNonArduPilotAutopilotLabel(autopilot: string | null | undefined): boolean {
+  if (!autopilot || autopilot === 'Unknown') return false;
+  return !isArduPilotAutopilotLabel(autopilot);
+}
+
+export function resolveArduPilotDocsContext(opts: {
+  protocol?: string | null;
+  autopilot?: string | null;
+  mavType?: number | null;
+  vehicleType?: string | null;
+  firmwareVersion?: string | null;
+  offlineVehicleType?: string | null;
+}): { vehicleType: VehicleType; versionTag: string | null } | null {
+  const { protocol, autopilot, mavType, vehicleType, firmwareVersion, offlineVehicleType } = opts;
+
+  // MSP / Betaflight / iNav are not ArduPilot docs
+  if (protocol === 'msp') return null;
+
+  // Non-ArduPilot autopilot labels (PX4, BTFL, …) never get ardupilot.org param pages,
+  // even when protocol is missing or not yet classified.
+  if (isNonArduPilotAutopilotLabel(autopilot)) return null;
+
+  // Require a positive ArduPilot context signal before emitting docs links.
+  // Bare vehicleType alone (without offline file / mavlink / ArduPilot autopilot)
+  // is not enough — avoids inappropriate docs for generic "copter" labels.
+  const offlineResolved = offlineVehicleType
+    ? vehicleNameToVehicleType(offlineVehicleType)
+    : null;
+  const hasApContext =
+    offlineResolved != null ||
+    protocol === 'mavlink' ||
+    isArduPilotAutopilotLabel(autopilot);
+  if (!hasApContext) return null;
+
+  // Prefer offline vehicle type when explicitly provided (offline editor),
+  // so a stale live connection vehicleType cannot override the file's vehicle.
+  let resolved: VehicleType | null = offlineResolved;
+  if (!resolved && mavType != null) {
+    resolved = mavTypeToVehicleTypeStrict(mavType);
+  }
+  if (!resolved) {
+    resolved = vehicleNameToVehicleType(vehicleType);
+  }
+  if (!resolved) return null;
+
+  return {
+    vehicleType: resolved,
+    versionTag: parseFirmwareVersionTag(firmwareVersion),
+  };
+}
+
+/**
+ * Parse a vehicle display/header name into VehicleType (null if unknown).
+ * Only maps known ArduPilot vehicle families / MAV type display names — never invents a default.
+ */
+export function vehicleNameToVehicleType(name: string | null | undefined): VehicleType | null {
+  if (!name) return null;
+  const lower = name.trim().toLowerCase();
+  // Reject non-ArduPilot FC labels that might appear in headers/connection state
+  if (
+    /^(btfl|inav|clfl|betaflight|px4|emuflight|arducopter-msp)/i.test(lower) ||
+    lower.includes('betaflight') ||
+    lower.includes('px4')
+  ) {
+    return null;
+  }
+
+  // Exact VehicleType keys
+  if (lower === 'copter' || lower === 'plane' || lower === 'rover' || lower === 'sub' || lower === 'tracker') {
+    return lower;
+  }
+
+  // Common MAV_TYPE / heartbeat display names used in save headers and UI
+  if (
+    lower.includes('copter') ||
+    lower === 'quadcopter' ||
+    lower === 'quadrotor' ||
+    lower === 'hexarotor' ||
+    lower === 'hexa' ||
+    lower === 'octorotor' ||
+    lower === 'octo' ||
+    lower === 'tricopter' ||
+    lower === 'tri' ||
+    lower === 'dodecarotor' ||
+    lower === 'decarotor' ||
+    lower === 'helicopter' ||
+    lower === 'coaxial'
+  ) {
+    return 'copter';
+  }
+  if (
+    lower.includes('plane') ||
+    lower.includes('fixed') ||
+    lower === 'fixed-wing' ||
+    lower === 'fixed wing' ||
+    lower.includes('vtol') ||
+    lower === 'airship' ||
+    lower === 'flapping wing' ||
+    lower === 'kite' ||
+    lower === 'parafoil'
+  ) {
+    return 'plane';
+  }
+  if (lower.includes('rover') || lower.includes('boat') || lower === 'ground rover' || lower === 'surface boat') {
+    return 'rover';
+  }
+  if (lower.includes('sub') || lower === 'submarine') return 'sub';
+  if (lower.includes('tracker') || lower === 'antenna tracker' || lower === 'antennatracker') {
+    return 'tracker';
+  }
+
+  const mav = vehicleTypeToMavType(name);
+  return mav != null ? mavTypeToVehicleTypeStrict(mav) : null;
+}
+
+/** Map MAV_TYPE to VehicleType without defaulting unknown types to copter. */
+function mavTypeToVehicleTypeStrict(mavType: number): VehicleType | null {
+  switch (mavType) {
+    case 1: case 7: case 8: case 16: case 17: case 19: case 20: case 21:
+    case 22: case 23: case 24: case 25: case 28:
+      return 'plane';
+    case 2: case 3: case 4: case 13: case 14: case 15: case 29: case 35:
+      return 'copter';
+    case 10: case 11:
+      return 'rover';
+    case 12:
+      return 'sub';
+    case 5:
+      return 'tracker';
+    default:
+      return null;
+  }
 }
 
 // Map MAVLink MAV_TYPE to our VehicleType


### PR DESCRIPTION
I have read and agree to the ArduDeck Contributor License Agreement (CLA.md).

## Summary

Port of [ADOS Mission Control #53](https://github.com/altnautica/ADOSMissionControl/pull/53) parameter ergonomics into ArduDeck (adapted to Electron/desktop patterns; not a verbatim copy).

- **Docs links:** version-aware ArduPilot wiki URLs from vehicle type + firmware (stable `Vmajor.minor.patch` Sphinx pages when known; unversioned `parameters.html` fallback; never `…-stable-latest`; tracker → `antennatracker`). ArduPilot-only; non-AP gets no link.
- **UI:** portalled `ParamNameTooltip` (not clipped by virtualized rows) + ExternalLink on live **and** offline param tables; hover-only name trigger (keyboard docs via row ExternalLink).
- **Enum display:** non-edit cells show `value — Label` / bitmask summaries with float32-aware matching; editors unchanged.
- **File I/O:** hardened Mission Planner `.param` and QGroundControl `.params` (headers, comments, BOM, CRLF); explicit **Export QGC**; empty/unrecognized file feedback (no silent empty diffs); compare modal only when value diffs exist.
- **Plumbing:** `ConnectionState.firmwareVersion` from `AUTOPILOT_VERSION` (official stable tags only).

## Scope guard

- Does **not** replace online param-metadata fetch/cache
- No new metadata snapshot system

## Verification

| Check | Result |
|-------|--------|
| `vitest run` on `parameter-metadata.test.ts`, `param-display.test.ts`, `param-file-parser.test.ts` | **77 passed** |

## Test plan

- [ ] Connect ArduPilot craft (or SITL) → Parameters → hover names → tooltip description + **ArduPilot docs** link
- [ ] Link uses versioned Sphinx page when official firmware version known; otherwise `parameters.html#…`
- [ ] Non-ArduPilot / MSP: no docs link
- [ ] Enum params show `value — Label` when not editing
- [ ] Export MP `.param` and QGC `.params`; re-import/compare; empty/garbage file → clear error
- [ ] Offline param file open: tooltips/docs when vehicle type known; QGC types preserved on load