### PR TITLE
MAVFTP Tweaks

### DIFF
--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -3869,9 +3869,9 @@ function parseTelemetry(mainWindow: BrowserWindow, packet: MAVLinkPacket): void 
     case MSG_FILE_TRANSFER_PROTOCOL: {
       // FILE_TRANSFER_PROTOCOL (110) - route to FTP client
       // Payload: targetNetwork(1) + targetSystem(1) + targetComponent(1) + ftpPayload(251)
-      // MAVLink v2 trims trailing zeros, so payload can be much shorter than 254 bytes.
-      // Minimum useful FTP response: 3 (outer) + 12 (FTP header) = 15 bytes
-      if (ftpClient && payload.length >= 15) {
+      // MAVLink v2 trims trailing zeros: a bare ACK (ResetSessions, TerminateSession)
+      // arrives as ~9 bytes, so accept anything past the outer header and zero-pad.
+      if (ftpClient && payload.length > 3) {
         // Zero-pad to 251 bytes for the FTP parser (v2 trimming removed trailing zeros)
         const ftpPayload = new Uint8Array(251);
         const ftpBytes = payload.subarray(3);

--- a/apps/desktop/src/main/mavlink-ftp/ftp-client.test.ts
+++ b/apps/desktop/src/main/mavlink-ftp/ftp-client.test.ts
@@ -29,6 +29,8 @@ interface FcOptions {
   reportedSize?: number;
   /** NAK reads whose size differs from the first one, as ArduPilot's @PARAM filesystem does. */
   lockReadSize?: boolean;
+  /** NAK reads past the end with Fail instead of EOF. */
+  failPastEnd?: boolean;
 }
 
 /**
@@ -84,7 +86,7 @@ function attachFc(file: Uint8Array, opts: FcOptions = {}) {
         case FtpOpcode.ReadFile: {
           stats.reads++;
           if (sizeRejected(req)) { nak(req, FtpError.FailErrno); return; }
-          if (req.offset >= served) { nak(req, FtpError.EOF); return; }
+          if (req.offset >= served) { nak(req, opts.failPastEnd ? FtpError.Fail : FtpError.EOF); return; }
           const end = Math.min(req.offset + req.size, served);
           reply(req, { offset: req.offset, size: end - req.offset, data: file.subarray(req.offset, end) });
           return;
@@ -202,6 +204,16 @@ describe('MavlinkFtpClient with an estimated file size (ArduPilot @PARAM/param.p
     expect(await client.downloadFile('@PARAM/param.pck')).toEqual(file);
     expect(stats.bursts).toBe(1);
     expect(stats.reads).toBeGreaterThan(0);
+  });
+
+  it('trusts the reported size when the FC errors instead of sending EOF past the end', async () => {
+    for (const burst of [true, false]) {
+      // An exact multiple of the read size, so no short packet marks the end.
+      const file = makeFile(320);
+      const { client } = attachFc(file, { burst, failPastEnd: true });
+
+      expect(await client.downloadFile('/APM/LOGS/1.BIN')).toEqual(file);
+    }
   });
 
   it('reads sequentially past a wrong size estimate', async () => {

--- a/apps/desktop/src/main/mavlink-ftp/ftp-client.test.ts
+++ b/apps/desktop/src/main/mavlink-ftp/ftp-client.test.ts
@@ -25,6 +25,10 @@ interface FcOptions {
   servedBytes?: number;
   /** End each burst after this many packets, the way a bounded FC scheduler does. */
   burstMaxPackets?: number;
+  /** Size OpenFileRO reports when it differs from the file, as ArduPilot's @PARAM estimate does. */
+  reportedSize?: number;
+  /** NAK reads whose size differs from the first one, as ArduPilot's @PARAM filesystem does. */
+  lockReadSize?: boolean;
 }
 
 /**
@@ -53,6 +57,13 @@ function attachFc(file: Uint8Array, opts: FcOptions = {}) {
   const nak = (req: FtpPayload, err: number) =>
     reply(req, { opcode: FtpOpcode.Nak, size: 1, data: Uint8Array.of(err) });
 
+  let lockedSize: number | null = null;
+  const sizeRejected = (req: FtpPayload) => {
+    if (!opts.lockReadSize) return false;
+    lockedSize ??= req.size;
+    return req.size !== lockedSize;
+  };
+
   client = new MavlinkFtpClient({
     readSize: READ_SIZE,
     sendPacket: async (raw) => {
@@ -65,13 +76,14 @@ function attachFc(file: Uint8Array, opts: FcOptions = {}) {
 
         case FtpOpcode.OpenFileRO: {
           const size = new Uint8Array(4);
-          new DataView(size.buffer).setUint32(0, file.length, true);
+          new DataView(size.buffer).setUint32(0, opts.reportedSize ?? file.length, true);
           reply(req, { session: 1, size: 4, data: size });
           return;
         }
 
         case FtpOpcode.ReadFile: {
           stats.reads++;
+          if (sizeRejected(req)) { nak(req, FtpError.FailErrno); return; }
           if (req.offset >= served) { nak(req, FtpError.EOF); return; }
           const end = Math.min(req.offset + req.size, served);
           reply(req, { offset: req.offset, size: end - req.offset, data: file.subarray(req.offset, end) });
@@ -82,6 +94,7 @@ function attachFc(file: Uint8Array, opts: FcOptions = {}) {
           if (!opts.burst) { nak(req, FtpError.UnknownCommand); return; }
           stats.bursts++;
           stats.burstOffsets.push(req.offset);
+          if (sizeRejected(req)) { nak(req, FtpError.FailErrno); return; }
           if (req.offset >= served) { nak(req, FtpError.EOF); return; }
           const cap = opts.burstMaxPackets ?? Infinity;
           const stopAt = Math.min(served, req.offset + cap * req.size);
@@ -157,6 +170,47 @@ describe('MavlinkFtpClient burst download', () => {
 
     const data = await client.downloadFile('@PARAM/param.pck');
     expect(data).toEqual(file.subarray(0, 64));
+  });
+});
+
+describe('MavlinkFtpClient with an estimated file size (ArduPilot @PARAM/param.pck)', () => {
+  it('stops at the real end when OpenFileRO over-reports the size', async () => {
+    const file = makeFile(200);
+    const { client, stats } = attachFc(file, { burst: true, reportedSize: 320, lockReadSize: true });
+
+    expect(await client.downloadFile('@PARAM/param.pck')).toEqual(file);
+    expect(stats.bursts).toBe(1);
+    expect(stats.reads).toBe(0);
+  });
+
+  it('keeps reading when OpenFileRO under-reports the size', async () => {
+    const file = makeFile(300);
+    const { client } = attachFc(file, { burst: true, reportedSize: 100, lockReadSize: true });
+
+    expect(await client.downloadFile('@PARAM/param.pck')).toEqual(file);
+  });
+
+  it('patches dropped burst packets without changing the read size', async () => {
+    const file = makeFile(390);
+    const { client, stats } = attachFc(file, {
+      burst: true,
+      reportedSize: 480,
+      lockReadSize: true,
+      dropBurstPacket: (n) => n % 4 === 2,
+    });
+
+    expect(await client.downloadFile('@PARAM/param.pck')).toEqual(file);
+    expect(stats.bursts).toBe(1);
+    expect(stats.reads).toBeGreaterThan(0);
+  });
+
+  it('reads sequentially past a wrong size estimate', async () => {
+    for (const reportedSize of [100, 200, 320]) {
+      const file = makeFile(200);
+      const { client } = attachFc(file, { burst: false, reportedSize, lockReadSize: true });
+
+      expect(await client.downloadFile('@PARAM/param.pck')).toEqual(file);
+    }
   });
 });
 

--- a/apps/desktop/src/main/mavlink-ftp/ftp-client.ts
+++ b/apps/desktop/src/main/mavlink-ftp/ftp-client.ts
@@ -852,6 +852,8 @@ export class MavlinkFtpClient {
     for (;;) {
       // Always a full-size read: ArduPilot's @PARAM files NAK any size but the first one used.
       const chunk = await this.readFileChunk(offset, this.readSize);
+      // A failed read once the reported size is covered is a server erroring instead of sending EOF.
+      if (!chunk && offset >= sizeHint) break;
       if (!chunk) {
         this.log('warn', `FTP: read failed at offset ${offset}/${sizeHint}`);
         return null;
@@ -912,7 +914,8 @@ export class MavlinkFtpClient {
     let loggedGaps = false;
     for (;;) {
       let holes = file.mask.holeRanges(file.size);
-      if (holes.length === 0) {
+      const probing = holes.length === 0;
+      if (probing) {
         if (file.eof !== null) break;
         // Everything up to the size hint arrived without a short packet; probe past it for the real end.
         holes = [{ start: file.size, end: file.size + this.readSize }];
@@ -928,7 +931,14 @@ export class MavlinkFtpClient {
         for (let off = hole.start; off < hole.end; off += this.readSize) {
           // Always a full-size read: ArduPilot's @PARAM files NAK any size but the first one used.
           const chunk = await this.readFileChunk(off, this.readSize);
-          if (!chunk) break;
+          if (!chunk) {
+            // A server that errors instead of sending EOF past the end: trust the reported size.
+            if (probing) {
+              file.markEof(off);
+              progressed = true;
+            }
+            break;
+          }
           const eofBefore = file.eof;
           if (chunk.length < this.readSize) file.markEof(off + chunk.length);
           if (file.store(off, chunk) > 0 || file.eof !== eofBefore) progressed = true;

--- a/apps/desktop/src/main/mavlink-ftp/ftp-client.ts
+++ b/apps/desktop/src/main/mavlink-ftp/ftp-client.ts
@@ -47,8 +47,7 @@ export interface FtpClientOptions {
 
 /** In-flight BurstReadFile collection. */
 interface BurstState {
-  buffer: Uint8Array;
-  mask: Coverage;
+  file: DownloadBuffer;
   /** Bytes newly covered by this burst (repeats of already-held bytes don't count). */
   gained: number;
   /** Highest file offset the burst has delivered data up to. */
@@ -65,8 +64,19 @@ class Coverage {
   private bits: Uint8Array;
   filled = 0;
 
-  constructor(readonly size: number) {
+  constructor(public size: number) {
     this.bits = new Uint8Array((size + 7) >> 3);
+  }
+
+  grow(size: number): void {
+    if (size <= this.size) return;
+    const bytes = (size + 7) >> 3;
+    if (bytes > this.bits.length) {
+      const next = new Uint8Array(Math.max(bytes, this.bits.length * 2));
+      next.set(this.bits);
+      this.bits = next;
+    }
+    this.size = size;
   }
 
   has(i: number): boolean {
@@ -83,22 +93,18 @@ class Coverage {
     return true;
   }
 
-  get complete(): boolean {
-    return this.filled >= this.size;
-  }
-
-  /** First missing byte at or after `from`, or -1 if none. */
-  firstHoleFrom(from: number): number {
-    for (let i = from; i < this.size; i++) {
+  /** First missing byte in [from, limit), or -1 if none. */
+  firstHoleFrom(from: number, limit = this.size): number {
+    for (let i = from; i < limit; i++) {
       if (!this.has(i)) return i;
     }
     return -1;
   }
 
-  holeRanges(): Array<{ start: number; end: number }> {
+  holeRanges(limit = this.size): Array<{ start: number; end: number }> {
     const ranges: Array<{ start: number; end: number }> = [];
     let start = -1;
-    for (let i = 0; i < this.size; i++) {
+    for (let i = 0; i < limit; i++) {
       if (!this.has(i)) {
         if (start < 0) start = i;
       } else if (start >= 0) {
@@ -106,8 +112,59 @@ class Coverage {
         start = -1;
       }
     }
-    if (start >= 0) ranges.push({ start, end: this.size });
+    if (start >= 0) ranges.push({ start, end: limit });
     return ranges;
+  }
+}
+
+/**
+ * Download target that trusts the FC's end of file over OpenFileRO's size, which
+ * ArduPilot only estimates for @PARAM/param.pck (param count * 12).
+ */
+class DownloadBuffer {
+  private data: Uint8Array;
+  readonly mask: Coverage;
+  /** Real end of file, once a short read or EOF has revealed it. */
+  eof: number | null = null;
+
+  constructor(sizeHint: number) {
+    this.data = new Uint8Array(sizeHint);
+    this.mask = new Coverage(sizeHint);
+  }
+
+  /** Best current estimate of the file length. */
+  get size(): number {
+    return this.eof ?? this.mask.size;
+  }
+
+  get complete(): boolean {
+    return this.eof !== null && this.mask.firstHoleFrom(0, this.eof) < 0;
+  }
+
+  markEof(at: number): void {
+    this.eof = Math.min(this.eof ?? at, at);
+  }
+
+  /** Stores a chunk at `offset`; returns how many of its bytes were new. */
+  store(offset: number, bytes: Uint8Array): number {
+    const end = this.eof === null ? offset + bytes.length : Math.min(offset + bytes.length, this.eof);
+    if (end > this.data.length) {
+      const next = new Uint8Array(Math.max(end, this.data.length * 2));
+      next.set(this.data);
+      this.data = next;
+    }
+    this.mask.grow(end);
+    let gained = 0;
+    for (let i = offset; i < end; i++) {
+      if (!this.mask.add(i)) continue;
+      this.data[i] = bytes[i - offset]!;
+      gained++;
+    }
+    return gained;
+  }
+
+  result(): Uint8Array {
+    return this.data.slice(0, this.size);
   }
 }
 
@@ -783,38 +840,35 @@ export class MavlinkFtpClient {
 
   /**
    * Sequential download: send ReadFile, wait for ACK, advance offset, repeat.
-   * Simple and reliable. Fast on USB serial (<1ms round-trip per chunk).
+   * Reads until a short chunk or EOF, since `sizeHint` may only be an estimate.
    */
   private async sequentialDownload(
-    fileSize: number,
+    sizeHint: number,
     progress?: FtpProgressCallback,
   ): Promise<Uint8Array | null> {
-    const result = new Uint8Array(fileSize);
+    const file = new DownloadBuffer(sizeHint);
     let offset = 0;
 
-    while (offset < fileSize) {
-      const remaining = fileSize - offset;
-      const chunkSize = Math.min(this.readSize, remaining);
-
-      const chunk = await this.readFileChunk(offset, chunkSize);
+    for (;;) {
+      // Always a full-size read: ArduPilot's @PARAM files NAK any size but the first one used.
+      const chunk = await this.readFileChunk(offset, this.readSize);
       if (!chunk) {
-        this.log('warn', `FTP: read failed at offset ${offset}/${fileSize}`);
+        this.log('warn', `FTP: read failed at offset ${offset}/${sizeHint}`);
         return null;
       }
 
-      // EOF before the declared size: return what we actually hold rather than a
-      // zero-padded buffer the caller can't tell from a full file.
-      if (chunk.length === 0) return result.slice(0, offset);
-
-      result.set(chunk, offset);
+      file.store(offset, chunk);
       offset += chunk.length;
+      if (chunk.length < this.readSize) break;
 
       if (progress) {
-        progress(offset, fileSize);
+        progress(offset, Math.max(sizeHint, offset));
       }
     }
 
-    return result;
+    file.markEof(offset);
+    if (progress) progress(offset, offset);
+    return file.result();
   }
 
   /**
@@ -824,11 +878,10 @@ export class MavlinkFtpClient {
    * the holes never fill, leaving the caller to fall back to plain reads.
    */
   private async burstDownload(
-    fileSize: number,
+    sizeHint: number,
     progress?: FtpProgressCallback,
   ): Promise<Uint8Array | null> {
-    const buffer = new Uint8Array(fileSize);
-    const mask = new Coverage(fileSize);
+    const file = new DownloadBuffer(sizeHint);
 
     // Sweep the file with bursts, each starting past the last one's coverage.
     // Restarting at the first hole instead would re-send the whole tail on
@@ -836,11 +889,11 @@ export class MavlinkFtpClient {
     let cursor = 0;
     let barren = 0;
     let anyBurstData = false;
-    while (cursor < fileSize && barren < 2) {
-      const start = mask.firstHoleFrom(cursor);
+    while (cursor < file.size && barren < 2) {
+      const start = file.mask.firstHoleFrom(cursor, file.size);
       if (start < 0) break;
 
-      const outcome = await this.runBurst(start, buffer, mask, progress, fileSize);
+      const outcome = await this.runBurst(start, file, progress);
       if (outcome.gained > 0) anyBurstData = true;
       // A silent first burst means the FC has no BurstReadFile; once bytes have
       // flowed, silence is just a lost request and the gap pass mops it up.
@@ -856,44 +909,47 @@ export class MavlinkFtpClient {
 
     // Whatever the bursts dropped is now a set of small holes; fetch each one
     // directly rather than replaying the stream.
-    for (let attempt = 0; attempt < FTP_MAX_RETRIES; attempt++) {
-      const holes = mask.holeRanges();
-      if (holes.length === 0) return buffer;
-      if (attempt === 0) {
+    let loggedGaps = false;
+    for (;;) {
+      let holes = file.mask.holeRanges(file.size);
+      if (holes.length === 0) {
+        if (file.eof !== null) break;
+        // Everything up to the size hint arrived without a short packet; probe past it for the real end.
+        holes = [{ start: file.size, end: file.size + this.readSize }];
+      } else if (!loggedGaps) {
+        loggedGaps = true;
         const missing = holes.reduce((n, h) => n + (h.end - h.start), 0);
         this.log('debug', `FTP: patching ${holes.length} burst gap(s), ${missing} bytes`);
       }
 
+      // Each round must gain bytes or find the end, so this terminates on a finite file.
       let progressed = false;
       for (const hole of holes) {
         for (let off = hole.start; off < hole.end; off += this.readSize) {
-          const size = Math.min(this.readSize, hole.end - off);
-          const chunk = await this.readFileChunk(off, size);
-          if (!chunk || chunk.length === 0) break;
-          for (let k = 0; k < chunk.length && off + k < fileSize; k++) {
-            if (!mask.add(off + k)) continue;
-            buffer[off + k] = chunk[k]!;
-            progressed = true;
-          }
-          if (progress) progress(mask.filled, fileSize);
+          // Always a full-size read: ArduPilot's @PARAM files NAK any size but the first one used.
+          const chunk = await this.readFileChunk(off, this.readSize);
+          if (!chunk) break;
+          const eofBefore = file.eof;
+          if (chunk.length < this.readSize) file.markEof(off + chunk.length);
+          if (file.store(off, chunk) > 0 || file.eof !== eofBefore) progressed = true;
+          if (progress) progress(file.mask.filled, file.size);
+          if (chunk.length < this.readSize) break;
         }
       }
       if (!progressed) break;
     }
 
-    if (!mask.complete) {
-      this.log('warn', `FTP: burst download incomplete (${mask.filled}/${fileSize} bytes)`);
+    if (!file.complete) {
+      this.log('warn', `FTP: burst download incomplete (${file.mask.filled}/${file.size} bytes)`);
       return null;
     }
-    return buffer;
+    return file.result();
   }
 
   private runBurst(
     offset: number,
-    buffer: Uint8Array,
-    mask: Coverage,
+    file: DownloadBuffer,
     progress: FtpProgressCallback | undefined,
-    fileSize: number,
   ): Promise<{ reason: BurstOutcome; gained: number; reachedEnd: number }> {
     return new Promise((resolve) => {
       let settled = false;
@@ -904,11 +960,11 @@ export class MavlinkFtpClient {
         const reachedEnd = this.burst?.reachedEnd ?? offset;
         if (this.burst?.timer) clearTimeout(this.burst.timer);
         this.burst = null;
-        if (progress) progress(mask.filled, fileSize);
+        if (progress) progress(file.mask.filled, file.size);
         resolve({ reason, gained, reachedEnd });
       };
 
-      this.burst = { buffer, mask, gained: 0, reachedEnd: offset, finish, timer: null, idleMs: FTP_TIMEOUT_MS };
+      this.burst = { file, gained: 0, reachedEnd: offset, finish, timer: null, idleMs: FTP_TIMEOUT_MS };
       this.armBurstTimer();
 
       const payload = this.buildPayload({
@@ -955,13 +1011,12 @@ export class MavlinkFtpClient {
 
     if (payload.opcode !== FtpOpcode.Ack) return;
 
-    const end = Math.min(payload.offset + payload.size, burst.buffer.length);
-    burst.reachedEnd = Math.max(burst.reachedEnd, end);
-    for (let i = payload.offset; i < end; i++) {
-      if (!burst.mask.add(i)) continue;
-      burst.buffer[i] = payload.data[i - payload.offset]!;
-      burst.gained++;
+    // A short packet is the file's last; OpenFileRO's size may have been only an estimate.
+    if (payload.size > 0 && payload.size < this.readSize) {
+      burst.file.markEof(payload.offset + payload.size);
     }
+    burst.gained += burst.file.store(payload.offset, payload.data.subarray(0, payload.size));
+    burst.reachedEnd = Math.max(burst.reachedEnd, payload.offset + payload.size);
 
     // After the first packet the FC is actively streaming, so a much shorter gap
     // means "burst is over" instead of another full round-trip timeout.

--- a/apps/desktop/src/main/mavlink-ftp/ftp-types.ts
+++ b/apps/desktop/src/main/mavlink-ftp/ftp-types.ts
@@ -153,5 +153,5 @@ export const FTP_BURST_TIMEOUT_MS = 1500;
 /** Max retries per operation */
 export const FTP_MAX_RETRIES = 5;
 
-/** Virtual file path for packed parameters */
-export const PARAM_PCK_PATH = '@PARAM/param.pck';
+/** Virtual file path for packed parameters. Firmware without defaults support ignores the query (as Mission Planner relies on). */
+export const PARAM_PCK_PATH = '@PARAM/param.pck?withdefaults=1';

--- a/apps/desktop/src/main/mavlink-ftp/param-pack-parser.test.ts
+++ b/apps/desktop/src/main/mavlink-ftp/param-pack-parser.test.ts
@@ -19,6 +19,27 @@ function buildPack(names: string[], declaredCount = names.length, totalParams = 
   return new Uint8Array(bytes);
 }
 
+describe('param.pck defaults', () => {
+  it('reads stored defaults and treats an entry without one as at its default', () => {
+    const bytes = [
+      0x1c, 0x67, 2, 0, 2, 0, // magic with defaults, 2 of 2 params
+      0x11, 0x10, 0x41, 0x31, 7, 3, // int8 "A1", default flag: value 7, default 3
+      0x01, 0x01, 0x32, 5, // int8 "A2" (shares "A"), no default stored: value 5
+    ];
+    const result = parseParamPack(new Uint8Array(bytes));
+    expect(result!.withDefaults).toBe(true);
+    expect(result!.params).toEqual([
+      { name: 'A1', value: 7, type: expect.any(Number), defaultValue: 3 },
+      { name: 'A2', value: 5, type: expect.any(Number), defaultValue: 5 },
+    ]);
+  });
+
+  it('leaves defaults unknown for a file without them', () => {
+    const result = parseParamPack(buildPack(['RTL_ALT']));
+    expect(result!.params[0]!.defaultValue).toBeUndefined();
+  });
+});
+
 describe('param.pck truncation detection', () => {
   it('marks a fully decoded file complete', () => {
     const pack = buildPack(['WPNAV_SPD', 'RTL_ALT', 'ATC_RAT_X']);

--- a/apps/desktop/src/main/mavlink-ftp/param-pack-parser.ts
+++ b/apps/desktop/src/main/mavlink-ftp/param-pack-parser.ts
@@ -184,6 +184,9 @@ export function parseParamPack(data: Uint8Array): ParamPackResult | null {
       if (offset + valSize > data.length) break;
       defaultValue = toFloat32Value(readValue(view, offset, ptype), ptype);
       offset += valSize;
+    } else if (withDefaults) {
+      // The firmware omits the default only when the value equals it.
+      defaultValue = value;
     }
 
     params.push({


### PR DESCRIPTION
I have read and agree to the ArduDeck Contributor License Agreement (CLA.md).

- Parameters now include defaults
- FTP no longer trust reported size, as it can differ
- Short FTP Acks no longer dropped
- Tests added

Should resolve issues with slow (1.5 kbytes / sec) links, also tested directly to FC over USB and didn't see any bad behavior.